### PR TITLE
nvdajp/nvdajp#19 ti35951 experimental ThreadSafe mode in kgs driver

### DIFF
--- a/source/brailleDisplayDrivers/kgs.py
+++ b/source/brailleDisplayDrivers/kgs.py
@@ -333,6 +333,7 @@ def bmDisConnect(hBrl, port):
 class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	name = "kgs"
 	description = _(u"KGS BrailleMemo series")
+	isThreadSafe = True
 	_portName = None
 	_directBM = None
 


### PR DESCRIPTION
テスト用のバージョン

http://s.nvda.jp/nvda_2017.2jp-beta-170403-b236.exe

今のところ不具合の報告はない。