### PR TITLE
#30 use abbreviated landmark names only for nabcc mode in Japanese

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -445,7 +445,7 @@ nabccLandmarkLabels = {
 	"region": "rgn",
 }
 
-def getLandmarkLabelJp(s):
+def getLandmarkLabelJp(landmark):
 	if landmark == "region":
 		if config.conf["braille"]["expandAtCursor"]:
 			return nabccLandmarkLabels[landmark]

--- a/source/braille.py
+++ b/source/braille.py
@@ -434,6 +434,27 @@ nabccPositiveStateLabels = {
 nabccNegativeStateLabels = {
 	controlTypes.STATE_CHECKED: "( )",
 }
+nabccLandmarkLabels = {
+	"banner": "bnnr",
+	"complementary": "cmpl",
+	"contentinfo": "cinf",
+	"main": "main",
+	"navigation": "navi",
+	"search": "srch",
+	"form": "form",
+	"region": "rgn",
+}
+
+def getLandmarkLabelJp(s):
+	if landmark == "region":
+		if config.conf["braille"]["expandAtCursor"]:
+			return nabccLandmarkLabels[landmark]
+		else:
+			return landmarkLabels[landmark]
+	if config.conf["braille"]["expandAtCursor"]:
+		return "lmk %s" % nabccLandmarkLabels[landmark]
+	return _("lmk %s") % landmarkLabels[landmark]
+
 def _nvdajp(s):
 	if config.conf["braille"]["expandAtCursor"]:
 		return s

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1009,12 +1009,13 @@ class BrowseModeDocumentTextInfo(textInfos.TextInfo):
 				textList.append(field["name"])
 			except KeyError:
 				pass
-			if landmark == "region":
-				# The word landmark is superfluous for regions.
-				textList.append(braille.landmarkLabels[landmark])
-			else:
-				# Translators: This is brailled to indicate a landmark (example output: lmk main).
-				textList.append(_("lmk %s") % braille.landmarkLabels[landmark])
+			#if landmark == "region":
+			#	# The word landmark is superfluous for regions.
+			#	textList.append(braille.landmarkLabels[landmark])
+			#else:
+			#	# Translators: This is brailled to indicate a landmark (example output: lmk main).
+			#	textList.append(_("lmk %s") % braille.landmarkLabels[landmark])
+			textList.append(braille.getLandmarkLabelJp(landmark))
 		text = super(BrowseModeDocumentTextInfo, self).getControlFieldBraille(field, ancestors, reportStart, formatConfig)
 		if text:
 			textList.append(text)


### PR DESCRIPTION
* for NABCC mode, use abbreviated landmark names
* for non-NABCC mode, use translated landmark names (Japanese nvda.po)
