### PR TITLE
kgs braille devices: ignore NoInputGestureAction

### DIFF
--- a/source/brailleDisplayDrivers/kgs.py
+++ b/source/brailleDisplayDrivers/kgs.py
@@ -154,7 +154,10 @@ def nvdaKgsHandleKeyInfoProc(lpKeys):
 	else:
 		log.io("names %s" % '+'.join(names))
 	if len(names):
-		inputCore.manager.executeGesture(InputGesture(names, routingIndex))
+		try:
+			inputCore.manager.executeGesture(InputGesture(names, routingIndex))
+		except inputCore.NoInputGestureAction:
+			pass
 		return True
 	return False
 

--- a/source/brailleDisplayDrivers/kgsbn46.py
+++ b/source/brailleDisplayDrivers/kgsbn46.py
@@ -95,7 +95,10 @@ def nvdaKgsHandleKeyInfoProc(lpKeys):
 	else:
 		log.io("names %s" % '+'.join(names))
 	if len(names):
-		inputCore.manager.executeGesture(InputGesture(names, routingIndex))
+		try:
+			inputCore.manager.executeGesture(InputGesture(names, routingIndex))
+		except inputCore.NoInputGestureAction:
+			pass
 		return True
 	return False
 


### PR DESCRIPTION
他のディスプレイドライバは未定義のドット入力の組み合わせで
エラーを出さないようになっているので、
KGS 系のドライバーも同じようにする。