### PR TITLE
日本語訳の修正

### DIFF
--- a/source/locale/ja/LC_MESSAGES/nvda.po
+++ b/source/locale/ja/LC_MESSAGES/nvda.po
@@ -1166,7 +1166,7 @@ msgstr "アイルランド語1級点字"
 #. Translators: The name of a braille table displayed in the
 #. braille settings dialog.
 msgid "Irish grade 2"
-msgstr "アイルランド語1級点字"
+msgstr "アイルランド語2級点字"
 
 #. Translators: The name of a braille table displayed in the
 #. braille settings dialog.


### PR DESCRIPTION
「Irish grade 2」が「アイルランド語1級点字」になっていたのを修正しました。
