### PR TITLE
音声エンジン「Haruka」を修正

### DIFF
--- a/source/synthDrivers/msspeech_tts.py
+++ b/source/synthDrivers/msspeech_tts.py
@@ -12,7 +12,7 @@ from logHandler import log
 
 from .jtalk import _nvdajp_spellchar
 from .mssp import SynthDriver
-from .sapi5 import constants
+from .sapi5 import SpeechVoiceSpeakFlags
 
 
 class SynthDriver(SynthDriver):
@@ -57,5 +57,5 @@ class SynthDriver(SynthDriver):
 		#Pitch must always be hardcoded
 		pitch=(self._pitch/2)-25
 		text="<pitch absmiddle=\"%s\">%s</pitch>"%(pitch,text)
-		flags=constants.SVSFIsXML|constants.SVSFlagsAsync
+		flags=SpeechVoiceSpeakFlags.IsXML|SpeechVoiceSpeakFlags.Async
 		self.tts.Speak(text,flags)


### PR DESCRIPTION
NVDA 2022.1 で `synthDrivers.sapi5` 内の `constants.SVSF*` が削除されています。
これに伴って、日本語版に搭載されている音声エンジンの「Haruka」が読み込めなくなっていたので修正しました。
一応手元でテストしていますが、何かおかしなところがあれば、ご連絡ください。
