### PR TITLE
アドオン ストア内のアクションメニューの翻訳を修正

### DIFF
--- a/source/locale/ja/LC_MESSAGES/nvda.po
+++ b/source/locale/ja/LC_MESSAGES/nvda.po
@@ -14259,7 +14259,7 @@ msgstr "インストール済みのアドオン(互換性なし)(&I)"
 #. Translators: Label for an action that updates the selected addon
 msgctxt "addonStore"
 msgid "&Update"
-msgstr "NVDAを更新(&U)"
+msgstr "更新(&U)"
 
 #. Translators: Label for an action that replaces the selected addon with
 #. an add-on store version.
@@ -14270,17 +14270,17 @@ msgstr "置換(&P)"
 #. Translators: Label for an action that disables the selected addon
 msgctxt "addonStore"
 msgid "&Disable"
-msgstr "無効(&D)"
+msgstr "無効化(&D)"
 
 #. Translators: Label for an action that enables the selected addon
 msgctxt "addonStore"
 msgid "&Enable"
-msgstr "有効(&E)"
+msgstr "有効化(&E)"
 
 #. Translators: Label for an action that enables the selected addon
 msgctxt "addonStore"
 msgid "&Enable (override incompatibility)"
-msgstr "有効 (互換性なし)(&E)"
+msgstr "有効化 (互換性なし)(&E)"
 
 #. Translators: Label for an action that removes the selected addon
 msgctxt "addonStore"


### PR DESCRIPTION
アドオン ストア内のアクションメニューの翻訳を少し修正しました。
修正点は差分をご覧いただければと思います。
