### PR TITLE
Add test for WAIC-TEST-0029-01

### DIFF
--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -2863,3 +2863,19 @@ def test_ariaErrorMessage():
 		actualSpeech,
 		SPEECH_SEP.join(("Input 4", "edit", "invalid entry", "Error 4")),
 	)
+
+
+def test_waic_as_0029_01():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-01.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  link  メインページへ戻る",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"閉じる  button  このウィンドウを閉じると、入力された情報は破棄され、メインページに戻ります ideographic period",
+	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -169,3 +169,6 @@ styleNav
 aria-errormessage
 	[Documentation]	Test that aria-errormessage is reported correctly in focus and browse mode
 	test_ariaErrorMessage
+test_waic_as_0029_01
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (button要素 : aria-label属性と併用)
+	test waic as 0029 01


### PR DESCRIPTION
<!-- 以下のテンプレートを読み、記入してください。セクションの説明については、次のリンクを参照してください：
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
また、NVDA プロジェクトには市民および貢献者の行動規範があり、次のリンクで確認できます：
https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md。NV Access は、すべての貢献者およびコミュニティメンバーがこの文書に記載されたルールを読み、遵守することを期待しています。これには、問題やプルリクエストの作成やコメントが含まれます。

最初に PR をドラフトとしてオープンしてください。
レビューを希望する場合は、PR を「レビューの準備ができました」とマークしてください。
詳細については、次のリンクを参照してください：
https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md
-->

### 問題番号へのリンク：

### 問題の概要：

NVDA 日本語版をリリースするたびに、WAIC は [AS テスト](https://github.com/waic/as_test) を行い、特に [AS 情報](https://waic.jp/guideline/as/)（例: aria-describedby 属性の正しい動作）を整備する必要があります。

この作業は手動で行う必要があり、不定期なボランティア活動に依存しています。自動化により、特定の支援技術とブラウザの組み合わせに限られますが、AS 情報の整備を効率化できます。

さらに、可能であれば NVDA 日本語版のビルドやリリースにおいて、AS テストのリグレッションを防ぐべきです。これにより、以前のバージョンで正常に動作していた機能が新しいリリースで壊れることを防ぎ、ユーザーに対して一貫した品質を提供することができます。

### ユーザーに対する変更の説明

このプルリクエストは、`test_waic_as_0029_01` テストケースを追加し、`aria-describedby` 属性による説明ラベルの提供を検証します。このテストは、ボタン要素と `aria-label` 属性を併用した場合の動作を確認します。

https://github.com/waic/as_test/blob/master/WAIC-TEST/HTML/WAIC-TEST-0029-01.md

なお、システムテストではNVDAの読み上げを文字列として比較しています。これは「期待される結果」の一例に過ぎないため、文字列が一致しなかった場合は、テストを修正するか、ASでないと判断するか、詳細な検討が必要です。

### 開発アプローチの説明

テストは、特定の HTML 構造を持つページを読み込み、`aria-describedby` 属性が正しく機能するかどうかを確認します。テストは、NVDA が正しいスピーチを出力することを確認するために、スクリプトを使用して実行されます。

### テスト戦略：

- 既存のユニットテストとシステムテストに加えて、新しいシステムテストを追加します。
- ブラウザは Google Chrome に限られています。
- 本家版のテストに合わせて、NVDA の言語は en のまま出力を検証します。
- https://github.com/nvdajp/nvdajp/blob/betajp/readme-nvdajp.md

### プルリクエストに関する既知の問題：

特に既知の問題はありませんが、テストが他のテストに影響を与えないことを確認する必要があります。

### コードレビュー チェックリスト：

<!--
このチェックリストは、新しい PR でよく忘れられる項目のリマインダーです。
著者は、このプルリクエストを自己レビューしてください。
項目の関連性について考慮したことを確認してください。
項目が欠けている場合（例：ユニット / システムテスト）、PR で説明してください。
項目をチェックするには、`- [ ]` を `- [x]` に変更します。スペースに注意してください。
PR 作成後にチェックボックスをチェックすることもできます。
このチェックリストの詳細な説明は、次のリンクで確認できます：
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] ドキュメント：
  - 変更ログのエントリ
  - ユーザードキュメント
  - 開発者 / 技術ドキュメント
  - GUI 変更に対するコンテキストセンスのヘルプ
- [ ] テスト：
  - ユニットテスト
  - システム（エンドツーエンド）テスト
  - 手動テスト
- [ ] すべてのユーザーの UX を考慮：
  - スピーチ
  - 点字
  - 低視力
  - 異なるウェブブラウザ
  - 英語以外の言語 / 文化におけるローカリゼーション
- [ ] API は既存のアドオンと互換性があります。
- [ ] セキュリティ対策が講じられています。

<!-- 以下を保持してください -->
@coderabbitai summary