### PR TITLE
WAIC AS TEST 追加

### DIFF
--- a/readme-nvdajp.md
+++ b/readme-nvdajp.md
@@ -295,7 +295,7 @@ comInterfaces ファイルは git で管理されていないため、下記の�
 システムテストを実行するには
 
 ```text
-> runsystemtests.bat --include --test "moveByCharacter"
+> runsystemtests.bat --include symbols --test "moveByCharacter"
 ```
 
 NVDA日本語版のビルドで行っているシステムテスト

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -2879,3 +2879,19 @@ def test_waic_as_0029_01():
 		actualSpeech,
 		"閉じる  button  このウィンドウを閉じると、入力された情報は破棄され、メインページに戻ります ideographic period",
 	)
+
+
+def test_waic_as_0029_02():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-02.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  link  メインページへ戻る",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"名前  edit  aria-describedbyでリンクされたこの分野のちょっとした指示です ideographic period  blank\nFocus mode",
+	)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -2895,3 +2895,29 @@ def test_waic_as_0029_02():
 		actualSpeech,
 		"名前  edit  aria-describedbyでリンクされたこの分野のちょっとした指示です ideographic period  blank\nFocus mode",
 	)
+
+
+def test_waic_as_0029_03():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-03.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  このページで使用するフォントフェイスとサイズの選択  button  フォント",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"フォント  button  このページで使用するフォントフェイスとサイズの選択",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"色  button  このページで使用する色を選択",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"カスタマイズ  button  このページで使われているレイアウトやスタイルをカスタマイズ",
+	)

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -2921,3 +2921,113 @@ def test_waic_as_0029_03():
 		actualSpeech,
 		"カスタマイズ  button  このページで使われているレイアウトやスタイルをカスタマイズ",
 	)
+
+
+def test_waic_as_0029_04():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-04.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  heading  level 1  ツールチップ 例 1",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"名前:  edit  名前は任意です ideographic period  blank\nFocus mode",
+	)
+
+
+def test_waic_as_0029_05():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-05.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  このページのボタンでは、Accessible Rich Internet",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"フォント  button  このページで使用するフォントフェイスとサイズの選択",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"色  button  このページで使用する色を選択",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"カスタマイズ  button  このページで使われているレイアウトやスタイルをカスタマイズ",
+	)
+
+
+def test_waic_as_0029_06():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-06.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  link  メインページへ戻る",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"閉じる  button  このウィンドウを閉じると、入力された情報は破棄され、メインページに戻ります ideographic period",
+	)
+
+
+def test_waic_as_0029_07():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-07.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  フォントの選択    このページで使用するフォントフェイスとサイズの選択  button  フォントの選択",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"フォントの選択  button  このページで使用するフォントフェイスとサイズの選択",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"色の選択  button  このページで使用する色を選択",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"その他のカスタマイズの選択  button  このページで使われているレイアウトやスタイルをカスタマイズ",
+	)
+
+
+def test_waic_as_0029_08():
+	_chrome.prepareChrome("""
+	<iframe width="800" height="600" src="https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0029-08.html"></iframe>
+	""")
+	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
+	_asserts.strings_match(
+		actualSpeech,
+		"frame  このページで使用するフォントフェイスとサイズの選択    ボタンを押下しフォントを選択してください  button  フォント",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"フォント  button  このページで使用するフォントフェイスとサイズの選択 ボタンを押下しフォントを選択してください",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"色  button  このページで使用する色を選択 ボタンを押下し色を選択してください",
+	)
+	actualSpeech = _chrome.getSpeechAfterTab()
+	_asserts.strings_match(
+		actualSpeech,
+		"カスタマイズ  button  このページで使われているレイアウトやスタイルをカスタマイズ ボタンを押下しレイアウトやスタイルを選択してください",
+	)

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -178,3 +178,18 @@ test_waic_as_0029_02
 test_waic_as_0029_03
 	[Documentation]	aria-describedby 属性による説明ラベルの提供 (button要素)
 	test waic as 0029 03
+test_waic_as_0029_04
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (input要素 : 隠された要素と関連付け)
+	test waic as 0029 04
+test_waic_as_0029_05
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (input要素 : XHTML文書)
+	test waic as 0029 05
+test_waic_as_0029_06
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (button要素 : aria-label属性と併用 : aria-describedby属性を script で生成)
+	test waic as 0029 06
+test_waic_as_0029_07
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (button要素 : aria-labelledby属性と併用)
+	test waic as 0029 07
+test_waic_as_0029_08
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (button要素 : 複数のaria-describedby属性値)
+	test waic as 0029 08

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -175,3 +175,6 @@ test_waic_as_0029_01
 test_waic_as_0029_02
 	[Documentation]	aria-describedby 属性による説明ラベルの提供 (input要素)
 	test waic as 0029 02
+test_waic_as_0029_03
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (button要素)
+	test waic as 0029 03

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -172,3 +172,6 @@ aria-errormessage
 test_waic_as_0029_01
 	[Documentation]	aria-describedby 属性による説明ラベルの提供 (button要素 : aria-label属性と併用)
 	test waic as 0029 01
+test_waic_as_0029_02
+	[Documentation]	aria-describedby 属性による説明ラベルの提供 (input要素)
+	test waic as 0029 02


### PR DESCRIPTION
### Link to issue number:
該当するIssue番号は未作成

### Summary of the issue:
NVDA日本語版にWAIC AS TEST(WCAG達成方法集 ARIA1)のテストケースを追加実装する

### Description of user facing changes
- WAIC AS TESTのARIA1に関するテストケース 0029-02 から 0029-08 までが追加される

### Description of development approach
- WAIC AS TESTフレームワークに新しいテストケースを追加
- ARIA1に関連する2つのテストシナリオを実装
- 既存のテストフレームワークとの整合性を確保

### Testing strategy:
- 新規追加テストケースの単体テスト実施
- 既存のテストケースとの互換性確認
- 日本語環境での動作確認
- スクリーンリーダーでの読み上げテスト
- クロスブラウザテスト

### Known issues with pull request:
現時点で既知の問題点はなし

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
