### PR TITLE
Fix key echo inconsistency during fast typing

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -543,13 +543,16 @@ class EnhancedTermTypedCharSupport(Terminal):
 	#: Timely and reliable textChange events are required
 	#: to support password suppression.
 	_supportsTextChange = True
-	#: A queue of typed characters, to be dispatched on C{textChange}.
-	#: This queue allows NVDA to suppress typed passwords when needed.
-	_queuedChars = []
 	#: Whether the last typed character is a tab.
 	#: If so, we should temporarily disable filtering as completions may
 	#: be short.
 	_hasTab = False
+
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		#: A queue of typed characters, to be dispatched on C{textChange}.
+		#: This queue allows NVDA to suppress typed passwords when needed.
+		self._queuedChars = []
 
 	def _reportNewLines(self, lines):
 		# Perform typed character filtering, as typed characters are handled with events.


### PR DESCRIPTION
## 問題 / Problem

Issue #490 で報告された高速タイピング時のキーエコー不安定性を修正します。

## 症状 / Symptoms

- 高速タイピング時に最初のキーは正常に読み上げられるが、続くキーが不規則に読み上げられる
- 低速タイピング時は正常に動作
- MS-IME で発生、ATOK では発生しない

## 根本原因 / Root Cause

`EnhancedTermTypedCharSupport._queuedChars` がクラス変数として定義されていたため：

```python
# 問題のあるコード
class EnhancedTermTypedCharSupport(Terminal):
    _queuedChars = []  # ← クラス変数：全インスタンスで共有
```

この結果：
- 複数のテキストコントロール間でキューが共有される
- 高速タイピング時に競合状態が発生
- `append()` と `pop()` が同時実行され、文字の読み上げが漏れる

## 修正内容 / Fix

`_queuedChars` をインスタンス変数に変更：

```python
# 修正後のコード
class EnhancedTermTypedCharSupport(Terminal):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self._queuedChars = []  # ← インスタンス変数：独立したキュー
```

## 効果 / Effect

- 各テキストコントロールが独立したキューを持つ
- 競合状態が解消される
- 高速タイピング時も安定したキーエコーを実現

## テスト計画 / Test Plan

- [ ] 高速タイピングでキーエコーの安定性を確認
- [ ] MS-IME での動作確認
- [ ] ATOK での動作に影響がないことを確認
- [ ] 複数のテキストコントロール間での影響がないことを確認

fixes #490