### PR TITLE
Add debug logging for IME ESC key detection investigation

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -459,11 +459,22 @@ def handleInputCompositionEnd(result):
 			from NVDAObjects import inputComposition
 
 			gesture = inputComposition.lastKeyGesture
-			ctrl = (winUser.VK_CONTROL, False) in gesture.generalizedModifiers
-			if (gesture.vkCode == winUser.VK_ESCAPE) or ctrl and gesture.vkCode in (0x5A, 0xDB):
-				# Translators: a message when the IME cancelation status
-				speech.speakMessage(_("Clear"))
-				return
+			# Debug logging for Issue #481: ESC key detection in legacy IME
+			log.debug(f"IME cancellation debug: gesture={gesture}")
+			if gesture:
+				log.debug(f"IME cancellation debug: vkCode={gesture.vkCode}, modifiers={gesture.generalizedModifiers}")
+			else:
+				log.debug("IME cancellation debug: gesture is None")
+				# Check current key state as fallback
+				escapeState = winUser.getAsyncKeyState(winUser.VK_ESCAPE)
+				log.debug(f"IME cancellation debug: ESC key state={escapeState}")
+			
+			if gesture:
+				ctrl = (winUser.VK_CONTROL, False) in gesture.generalizedModifiers
+				if (gesture.vkCode == winUser.VK_ESCAPE) or ctrl and gesture.vkCode in (0x5A, 0xDB):
+					# Translators: a message when the IME cancelation status
+					speech.speakMessage(_("Clear"))
+					return
 			else:
 				result = curInputComposition.compositionString.lstrip("\u3000 ")
 				if winUser.getAsyncKeyState(winUser.VK_BACK) & 1:

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -331,6 +331,8 @@ def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 	if config.conf["keyboard"]["nvdajpEnableKeyEvents"]:
 		from NVDAObjects import inputComposition
 
+		# Debug logging for Issue #481: track key events for IME
+		log.debug(f"keyboardHandler: reportKeyDownEvent called with vkCode={gesture.vkCode}, modifiers={gesture.generalizedModifiers}")
 		inputComposition.reportKeyDownEvent(gesture)
 	# nvdajp end
 	return True


### PR DESCRIPTION
## 目的 / Purpose

Issue #481 で報告された旧版日本語IMEでのESCキー検出問題の原因調査のため、デバッグログを追加します。

## 問題 / Problem

**症状:**
- 旧版日本語IME使用時
- 日本語変換中にESCキーを押しても「クリア」音声が出ない
- 新しいIMEでは正常動作

**期待動作:**
- ESCキー押下時に「クリア」音声が再生される

## 追加したデバッグログ / Debug Logging Added

### 1. NVDAHelper.py (lines 463-470)
IME変換キャンセル検出時の詳細情報:
- `inputComposition.lastKeyGesture` の値
- ジェスチャーオブジェクトの `vkCode` と `modifiers`
- ジェスチャーが `None` の場合の代替キー状態チェック

### 2. keyboardHandler.py (lines 334-335)
キーイベント受信時の情報:
- `reportKeyDownEvent` 呼び出し時の `vkCode` と `modifiers`

## 調査項目 / Investigation Points

このデバッグログにより以下を確認できます：

1. **キーイベントフロー**: ESCキーが `keyboardHandler` に到達するか
2. **ジェスチャー設定**: `lastKeyGesture` が正しく設定されるか  
3. **タイミング問題**: IME変換終了時にジェスチャー情報が残っているか
4. **IME固有動作**: 旧版IMEと新版IMEの動作差異

## 使用方法 / Usage

1. NVDA設定でデバッグログレベルを有効化
2. 旧版日本語IMEで日本語入力・変換
3. ESCキーで変換をキャンセル
4. ログファイルで `IME cancellation debug:` を検索
5. 結果をIssue #481 にコメント

## 次のステップ / Next Steps

デバッグログの結果に基づいて根本原因を特定し、確実な修正を実装予定。

related #481