### PR TITLE
fix: resolve compatibility issues after beta merge (#514)

### DIFF
--- a/jptools/devbuild2024.cmd
+++ b/jptools/devbuild2024.cmd
@@ -1,7 +1,11 @@
 set VERSION=2024.4jp
 set VERSION_BUILD=99999
 del source\_buildVersion.py
-call venvUtils\venvCmd jptools\devbuild.cmd source version_build=%VERSION_BUILD% --all-cores
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+cd /d "%here%\.."
+call jptools\devbuild.cmd source version_build=%VERSION_BUILD% --all-cores
 @if not "%ERRORLEVEL%"=="0" goto onerror
 call rununittests.bat
 exit /b 0

--- a/jptools/jpDicTest.py
+++ b/jptools/jpDicTest.py
@@ -14,6 +14,9 @@ import os
 sys.path.append(os.path.normpath(os.path.join(os.getcwd(), "mocks")))
 sys.path.append(r"..\source")
 sys.path.append(r"..\miscdeps\python")
+
+# Import globalVars from mocks before any module that uses it
+import globalVars  # noqa: F401,E402
 import languageHandler
 
 languageHandler.setLanguage("ja")

--- a/jptools/jpDicTest.py
+++ b/jptools/jpDicTest.py
@@ -14,9 +14,6 @@ import os
 sys.path.append(os.path.normpath(os.path.join(os.getcwd(), "mocks")))
 sys.path.append(r"..\source")
 sys.path.append(r"..\miscdeps\python")
-
-# Import globalVars from mocks before any module that uses it
-import globalVars  # noqa: F401,E402
 import languageHandler
 
 languageHandler.setLanguage("ja")

--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -3,7 +3,7 @@
 !include "MUI2.nsh"
 
 !define launcher_appExe "nvdaLauncher.exe"
-!define MUI_ICON ..\source\images\nvda.ico
+!define MUI_ICON ..\source\images\nvdajp3.ico
 
 SetCompressor /SOLID LZMA
 SilentInstall silent

--- a/sconstruct
+++ b/sconstruct
@@ -286,7 +286,7 @@ for po in env.Glob(sourceDir.path + "/locale/*/lc_messages/*.po"):
 
 styles = os.path.join(userDocsDir.path, "styles.css")
 numberedHeadingsStyle = os.path.join(userDocsDir.path, "numberedHeadings.css")
-logo = os.path.join(sourceDir.path, "images", "nvda.ico")
+logo = os.path.join(sourceDir.path, "images", "nvdajp3.ico")
 favicon = env.Command(
 	outputDir.File("favicon.ico"),
 	logo,

--- a/uninstaller/uninst.nsi
+++ b/uninstaller/uninst.nsi
@@ -1,7 +1,7 @@
 !include "MUI2.nsh"
 
 !define appName "NVDA"
-!define MUI_UNICON ..\source\images\nvda.ico
+!define MUI_UNICON ..\source\images\nvdajp3.ico
 
 !define INSTDIR_REG_ROOT "HKLM"
 !define INSTDIR_REG_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${appName}"


### PR DESCRIPTION
#514

- Update jptools/devbuild2024.cmd to remove venvUtils dependency
- Restore Japanese version icons (nvdajp3.ico) in launcher, uninstaller, and sconstruct

