### PR TITLE
fix: update function names and ensure appDir initialization in jpDicTest.py #514

### DIFF
--- a/jptools/jpDicTest.py
+++ b/jptools/jpDicTest.py
@@ -17,7 +17,8 @@ sys.path.append(r"..\miscdeps\python")
 
 # Initialize globalVars.appDir before importing modules that depend on it
 import globalVars
-globalVars.appDir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if not hasattr(globalVars, 'appDir') or not globalVars.appDir:
+	globalVars.appDir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 import languageHandler
 
@@ -154,8 +155,8 @@ class JpUtilsTestCase(unittest.TestCase):
 			braille = jpUtils.getDiscriminantReading(source, forBraille=True)
 			self.assertEqual(braille_expected, braille)
 
-	def test_getDiscrptionForBraille(self):
-		self.assertEqual(jpUtils.getDiscrptionForBraille("a"), "半角 a")
+	def test_getDescriptionForBraille(self):
+		self.assertEqual(jpUtils.getDescriptionForBraille("a"), "半角 a")
 
 	def test_processHexCode(self):
 		self.assertEqual(jpUtils.processHexCode("ja", "u+0000"), "u+ゼロゼロゼロゼロ")

--- a/jptools/jpDicTest.py
+++ b/jptools/jpDicTest.py
@@ -1,7 +1,7 @@
 # coding: UTF-8
 # A part of NonVisual Desktop Access (NVDA)
 # by Takuya Nishimoto (NVDA Japanese Team)
-# jpDicTest.py for testing source/nvdajp_dic.py
+# jpDicTest.py for testing source/jpUtils.py
 # Usage:
 # > miscDeps\tools\msgfmt.exe source\locale\ja\LC_MESSAGES\nvda.po -o source\locale\ja\LC_MESSAGES\nvda.mo
 # > cd jptools
@@ -17,13 +17,49 @@ sys.path.append(r"..\miscdeps\python")
 
 # Initialize globalVars.appDir before importing modules that depend on it
 import globalVars
-if not hasattr(globalVars, 'appDir') or not globalVars.appDir:
+
+if not hasattr(globalVars, "appDir") or not globalVars.appDir:
 	globalVars.appDir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 import languageHandler
 
 languageHandler.setLanguage("ja")
-import jpUtils  # noqa: E402
+from jpUtils import (  # noqa: E402
+	getLongDesc,
+	getShortDesc,
+	isJa,
+	isZenkakuHiragana,
+	isZenkakuKatakana,
+	isHankakuKatakana,
+	isHalfShape,
+	isFullShapeAlphabet,
+	isHalfShapeAlphabet,
+	isFullShapeNumber,
+	isHalfShapeNumber,
+	isKanaCharacter,
+	isLatinCharacter,
+	isFullShapeSymbol,
+	isUpper,
+	replaceSpecialKanaCharacter,
+	getAttrDesc,
+	getJpAttr,
+	getCharDesc,
+	getPitchChangeForCharAttr,
+	getJaCharAttrDetails,
+	code2kana,
+	code2hex,
+	getCandidateCharDesc,
+	useAttrDesc,
+	getOrd,
+	splitChars,
+	getDiscriminantReading,
+	getDescriptionForBraille,
+	processHexCode,
+	fixNewText,
+	processKangxiRadicals,
+	CharAttr,
+	JpAttr,
+)
 
 # import locale
 import gettext  # noqa: E402
@@ -57,119 +93,119 @@ items = [
 
 class JpUtilsTestCase(unittest.TestCase):
 	def test_getLongDesc(self):
-		self.assertEqual(jpUtils.getLongDesc("a"), "エー アルファー")
+		self.assertEqual(getLongDesc("a"), "エー アルファー")
 
 	def test_getShortDesc(self):
-		self.assertEqual(jpUtils.getShortDesc("a"), "エー アルファー")
+		self.assertEqual(getShortDesc("a"), "エー アルファー")
 
 	def test_isJa(self):
-		self.assertTrue(jpUtils.isJa("ja"))
+		self.assertTrue(isJa("ja"))
 
 	def test_isZenkakuHiragana(self):
-		self.assertTrue(jpUtils.isZenkakuHiragana("あ"))
+		self.assertTrue(isZenkakuHiragana("あ"))
 
 	def test_isZenkakuKatakana(self):
-		self.assertTrue(jpUtils.isZenkakuKatakana("ア"))
+		self.assertTrue(isZenkakuKatakana("ア"))
 
 	def test_isHankakuKatakana(self):
-		self.assertTrue(jpUtils.isHankakuKatakana("ｱ"))
+		self.assertTrue(isHankakuKatakana("ｱ"))
 
 	def test_isHalfShape(self):
-		self.assertTrue(jpUtils.isHalfShape("1"))
+		self.assertTrue(isHalfShape("1"))
 
 	def test_isFullShapeAlphabet(self):
-		self.assertTrue(jpUtils.isFullShapeAlphabet("Ａ"))
+		self.assertTrue(isFullShapeAlphabet("Ａ"))
 
 	def test_isHalfShapeAlphabet(self):
-		self.assertTrue(jpUtils.isHalfShapeAlphabet("A"))
+		self.assertTrue(isHalfShapeAlphabet("A"))
 
 	def test_isFullShapeNumber(self):
-		self.assertTrue(jpUtils.isFullShapeNumber("１"))
+		self.assertTrue(isFullShapeNumber("１"))
 
 	def test_isHalfShapeNumber(self):
-		self.assertTrue(jpUtils.isHalfShapeNumber("1"))
+		self.assertTrue(isHalfShapeNumber("1"))
 
 	def test_isKanaCharacter(self):
-		self.assertTrue(jpUtils.isKanaCharacter("ア"))
+		self.assertTrue(isKanaCharacter("ア"))
 
 	def test_isLatinCharacter(self):
-		self.assertTrue(jpUtils.isLatinCharacter("a"))
+		self.assertTrue(isLatinCharacter("a"))
 
 	def test_isFullShapeSymbol(self):
-		self.assertTrue(jpUtils.isFullShapeSymbol("＠"))
+		self.assertTrue(isFullShapeSymbol("＠"))
 
 	def test_isUpper(self):
-		self.assertTrue(jpUtils.isUpper("A"))
+		self.assertTrue(isUpper("A"))
 
 	def test_replaceSpecialKanaCharacter(self):
-		self.assertEqual(jpUtils.replaceSpecialKanaCharacter("ー"), "チョーオン")
+		self.assertEqual(replaceSpecialKanaCharacter("ー"), "チョーオン")
 
 	def test_getAttrDesc(self):
-		a = jpUtils.CharAttr(True, False, False, False, False, False)
-		self.assertEqual(jpUtils.getAttrDesc(a), "オオモジ ")
+		a = CharAttr(True, False, False, False, False, False)
+		self.assertEqual(getAttrDesc(a), "オオモジ ")
 
 	def test_getJpAttr(self):
-		a = jpUtils.getJpAttr("ja", "a", False)
-		self.assertEqual(type(a), jpUtils.JpAttr)
+		a = getJpAttr("ja", "a", False)
+		self.assertEqual(type(a), JpAttr)
 		self.assertTrue(a.jpLatinCharacter)
 
 	def test_getCharDesc(self):
-		a = jpUtils.getJpAttr("ja", "a", False)
-		desc = jpUtils.getCharDesc("ja", "a", a)
+		a = getJpAttr("ja", "a", False)
+		desc = getCharDesc("ja", "a", a)
 		self.assertEqual(desc, ("エー アルファー",))
 
 	def test_getPitchChangeForCharAttr(self):
-		a = jpUtils.getJpAttr("ja", "A", False)
-		pitchChange = jpUtils.getPitchChangeForCharAttr("ja", a, True)
+		a = getJpAttr("ja", "A", False)
+		pitchChange = getPitchChangeForCharAttr("ja", a, True)
 		self.assertEqual(pitchChange, True)
 
 	def test_getJaCharAttrDetails(self):
-		self.assertEqual(jpUtils.getJaCharAttrDetails("A", False, True), "半角 英字")
+		self.assertEqual(getJaCharAttrDetails("A", False, True), "半角 英字")
 
 	def test_code2kana(self):
-		self.assertEqual(jpUtils.code2kana(0x0123), "ゼロイチニーサン")
+		self.assertEqual(code2kana(0x0123), "ゼロイチニーサン")
 
 	def test_code2hex(self):
-		self.assertEqual(jpUtils.code2hex(0x123A), "u+123a")
+		self.assertEqual(code2hex(0x123A), "u+123a")
 
 	def test_getCandidateCharDesc(self):
-		a = jpUtils.CharAttr(True, False, False, False, False, False)
-		self.assertEqual(jpUtils.getCandidateCharDesc("a", a, False), " エー アルファー ")
+		a = CharAttr(True, False, False, False, False, False)
+		self.assertEqual(getCandidateCharDesc("a", a, False), " エー アルファー ")
 
 	def test_useAttrDesc(self):
-		a = jpUtils.CharAttr(True, False, False, False, False, False)
-		self.assertEqual(jpUtils.useAttrDesc(["ー", a]), False)
-		self.assertEqual(jpUtils.useAttrDesc(["あ", a]), True)
+		a = CharAttr(True, False, False, False, False, False)
+		self.assertEqual(useAttrDesc(["ー", a]), False)
+		self.assertEqual(useAttrDesc(["あ", a]), True)
 
 	def test_getOrd(self):
-		self.assertEqual(jpUtils.getOrd("a"), 97)
-		self.assertEqual(jpUtils.getOrd("𞀄"), 0x1E004)
+		self.assertEqual(getOrd("a"), 97)
+		self.assertEqual(getOrd("𞀄"), 0x1E004)
 
 	def test_splitChars(self):
-		self.assertEqual(jpUtils.splitChars("a𞀄"), ["a", "𞀄"])
+		self.assertEqual(splitChars("a𞀄"), ["a", "𞀄"])
 
 	def test_getDiscriminantReading(self):
 		for source, saycap_expected, braille_expected in items:
-			saycap = jpUtils.getDiscriminantReading(source, sayCapForCapitals=True)
+			saycap = getDiscriminantReading(source, sayCapForCapitals=True)
 			self.assertEqual(saycap_expected, saycap)
-			braille = jpUtils.getDiscriminantReading(source, forBraille=True)
+			braille = getDiscriminantReading(source, forBraille=True)
 			self.assertEqual(braille_expected, braille)
 
 	def test_getDescriptionForBraille(self):
-		self.assertEqual(jpUtils.getDescriptionForBraille("a"), "半角 a")
+		self.assertEqual(getDescriptionForBraille("a"), "半角 a")
 
 	def test_processHexCode(self):
-		self.assertEqual(jpUtils.processHexCode("ja", "u+0000"), "u+ゼロゼロゼロゼロ")
+		self.assertEqual(processHexCode("ja", "u+0000"), "u+ゼロゼロゼロゼロ")
 
 	def test_fixNewText(self):
-		self.assertEqual(jpUtils.fixNewText("あ"), "ア")
-		self.assertEqual(jpUtils.fixNewText("ー"), " チョーオン ")
+		self.assertEqual(fixNewText("あ"), "ア")
+		self.assertEqual(fixNewText("ー"), " チョーオン ")
 
 	def test_processKangxiRadicals(self):
-		self.assertEqual(jpUtils.processKangxiRadicals("簡単に⾔えば"), "簡単に言えば")
-		self.assertEqual(jpUtils.processKangxiRadicals("⾃由な発想"), "自由な発想")
-		self.assertEqual(jpUtils.processKangxiRadicals("公益財団法⼈"), "公益財団法人")
-		self.assertEqual(jpUtils.processKangxiRadicals("富⼭⽂化"), "富山文化")
+		self.assertEqual(processKangxiRadicals("簡単に⾔えば"), "簡単に言えば")
+		self.assertEqual(processKangxiRadicals("⾃由な発想"), "自由な発想")
+		self.assertEqual(processKangxiRadicals("公益財団法⼈"), "公益財団法人")
+		self.assertEqual(processKangxiRadicals("富⼭⽂化"), "富山文化")
 
 
 if __name__ == "__main__":

--- a/source/jpUtils.py
+++ b/source/jpUtils.py
@@ -404,7 +404,7 @@ def getDiscriminantReading(
 	return r
 
 
-def getDiscrptionForBraille(name, attrOnly=False, sayCapForCapitals=False):
+def getDescriptionForBraille(name, attrOnly=False, sayCapForCapitals=False):
 	return getDiscriminantReading(
 		name, attrOnly=attrOnly, sayCapForCapitals=sayCapForCapitals, forBraille=True
 	)


### PR DESCRIPTION
#514
- Corrected the function name from `getDiscrptionForBraille` to `getDescriptionForBraille` for consistency.
- Added a check to initialize `globalVars.appDir` only if it is not already set, improving robustness.

