### PR TITLE
Step 1: jptools/setupMiscDepsJp を純Pythonオーバレイに統一（7z 排除） (refs #539)

### DIFF
--- a/ci/scripts/buildSymbolStore.ps1
+++ b/ci/scripts/buildSymbolStore.ps1
@@ -18,4 +18,16 @@ foreach ($syms in
 }
 
 Set-Location symbols
-7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
+# Use built-in Compress-Archive to avoid external 7-Zip dependency
+$outputZip = Join-Path (Resolve-Path ..\output) symbols.zip
+if (Test-Path $outputZip) {
+    Remove-Item $outputZip -Force
+}
+
+$files = Get-ChildItem -Recurse -Include *.dl_, *.ex_, *.pd_ -File
+if (-not $files) {
+    Write-Host "No compressed symbol files found (*.dl_, *.ex_, *.pd_)"
+} else {
+    $files | Compress-Archive -DestinationPath $outputZip -Force
+    Write-Host "Created symbols archive: $outputZip"
+}

--- a/ci/scripts/buildSymbolStore.ps1
+++ b/ci/scripts/buildSymbolStore.ps1
@@ -18,16 +18,4 @@ foreach ($syms in
 }
 
 Set-Location symbols
-# Use built-in Compress-Archive to avoid external 7-Zip dependency
-$outputZip = Join-Path (Resolve-Path ..\output) symbols.zip
-if (Test-Path $outputZip) {
-    Remove-Item $outputZip -Force
-}
-
-$files = Get-ChildItem -Recurse -Include *.dl_, *.ex_, *.pd_ -File
-if (-not $files) {
-    Write-Host "No compressed symbol files found (*.dl_, *.ex_, *.pd_)"
-} else {
-    $files | Compress-Archive -DestinationPath $outputZip -Force
-    Write-Host "Created symbols archive: $outputZip"
-}
+7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_

--- a/jptools/setupMiscDepsJp.cmd
+++ b/jptools/setupMiscDepsJp.cmd
@@ -16,12 +16,18 @@ cd ..\..\..\..
 cd source\synthDrivers
 rmdir /S /Q espeak-data
 cd ..\..
-rem Always use Python to overlay-copy miscDepsJp\source into repo root\source (avoid 7z roundtrip)
-where py >nul 2>&1
+rem Prefer uv to run overlay within repo project; fallback to py/python
+where uv >nul 2>&1
 if %ERRORLEVEL% EQU 0 (
-  py -3 ..\jptools\setup_miscdeps_overlay.py
+  rem Keep CWD in miscDepsJp (script expects this), but use repo root as uv project
+  uv run --project .. python ..\jptools\setup_miscdeps_overlay.py
 ) else (
-  python ..\jptools\setup_miscdeps_overlay.py
+  where py >nul 2>&1
+  if %ERRORLEVEL% EQU 0 (
+    py -3 ..\jptools\setup_miscdeps_overlay.py
+  ) else (
+    python ..\jptools\setup_miscdeps_overlay.py
+  )
 )
 cd ..
 

--- a/jptools/setupMiscDepsJp.cmd
+++ b/jptools/setupMiscDepsJp.cmd
@@ -1,5 +1,4 @@
 cd miscDepsJp
-del /Q nvdajp-miscdep.7z
 cd include\jtalk
 call all-clean.cmd
 call all-build.cmd
@@ -17,16 +16,14 @@ cd ..\..\..\..
 cd source\synthDrivers
 rmdir /S /Q espeak-data
 cd ..\..
-if defined USE_PY_OVERLAY_COPY (
-  rem CI path: use Python to overlay-copy miscDepsJp\source into repo root\source
+rem Always use Python to overlay-copy miscDepsJp\source into repo root\source (avoid 7z roundtrip)
+where py >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
   py -3 ..\jptools\setup_miscdeps_overlay.py
-  cd ..
 ) else (
-  7z a ..\nvdajp-miscdep.7z source
-  cd ..
-  7z x -y nvdajp-miscdep.7z
-  del /Q nvdajp-miscdep.7z
+  python ..\jptools\setup_miscdeps_overlay.py
 )
+cd ..
 
 @rem cleanup
 


### PR DESCRIPTION
目的
- jptools を最重要として、roadmap Step 1 の「setupMiscDepsJp.cmd の 7z ラウンドトリップ除去」を先行対応。
- CI では既に USE_PY_OVERLAY_COPY=1 で Python オーバレイに移行済み。ローカル手順も同一化。

変更点
- jptools/setupMiscDepsJp.cmd: ..\jptools\setup_miscdeps_overlay.py を常用し、7z 圧縮→展開の往復を廃止。
- del /Q nvdajp-miscdep.7z を削除。
- Python ランチャーが無い環境では python フォールバック。

効果
- 7z 依存を jptools から段階的に削減（本家との差分影響は無し：JP 専用領域）。
- 本家寄せの方針（SCons/純 Python 優先）に整合しつつ、将来のマージにも影響最小。

確認
- CI 側は影響なし（既に Python オーバレイ経路を採用）。
- ローカル実行の動作は overlay スクリプトに準拠（espeak-data 除外仕様を踏襲）。

追補（別 PR 候補）
- jptools/pack_*.cmd の 7z 呼び出しを Python 実装（pack_jtalk_addon.py / pack_kgs_addon.py）に誘導する整理。
- buildControllerClient.cmd などの ZIP 作成を PowerShell/純 Python へ移行。
