### PR TITLE
CI: Add typeCheck + advisory lint to testAndPublish (Step 1, refs #539)

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -44,6 +44,36 @@ jobs:
       shell: pwsh
       run: ci/scripts/tests/typeCheck.ps1
 
+  lint:
+    name: Ruff format and lint (advisory)
+    runs-on: windows-2025
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Set up Python 3.11 x86
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: 'x86'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
+    - name: Run ruff format --check (advisory)
+      continue-on-error: true
+      shell: pwsh
+      run: uv run ruff format --check
+
+    - name: Run ruff check (advisory)
+      continue-on-error: true
+      shell: pwsh
+      run: uv run ruff check
+
   buildNVDA:
     runs-on: windows-2025
     outputs:

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -20,6 +20,30 @@ env:
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
 
 jobs:
+  typeCheck:
+    name: Static type analysis (pyright)
+    runs-on: windows-2025
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Set up Python 3.11 x86
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: 'x86'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
+    - name: Run type check (pyright)
+      shell: pwsh
+      run: ci/scripts/tests/typeCheck.ps1
+
   buildNVDA:
     runs-on: windows-2025
     outputs:
@@ -587,7 +611,7 @@ jobs:
     # Used to protect branches/tags as a general status check so we can check a single job for all rulesets.
     name: Check if all tests pass
     runs-on: ubuntu-latest
-    needs: [buildNVDA, checkPo, checkPot, licenseCheck, unitTests, createLauncher, systemTests, createSymbols]
+    needs: [buildNVDA, checkPo, checkPot, typeCheck, licenseCheck, unitTests, createLauncher, systemTests, createSymbols]
     steps:
     - name: Check if all tests pass
       run: echo "All tests passed successfully."

--- a/projectDocs/jp/README.md
+++ b/projectDocs/jp/README.md
@@ -19,6 +19,7 @@
 
 ## CI/ビルド クイックスタート
 - 型チェックのみ（本家版寄せ・安全導入）: `.github/workflows/nvbeta-typecheck-311x86.yml`
+- 包括パイプラインにも `typeCheck` ジョブを追加（3.11 x86／pyright）
 - 日本語版フルビルド・配布系: `.github/workflows/testAndPublish.yml`
 - ローカル最小ビルド例: `scons --help` を確認し、通常は `scons source dist launcher --all-cores`
 - 単体/システムテスト: `ci/scripts/tests/unitTests.ps1`、`ci/scripts/tests/systemTests.ps1`

--- a/projectDocs/jp/README.md
+++ b/projectDocs/jp/README.md
@@ -20,6 +20,7 @@
 ## CI/ビルド クイックスタート
 - 型チェックのみ（本家版寄せ・安全導入）: `.github/workflows/nvbeta-typecheck-311x86.yml`
 - 包括パイプラインにも `typeCheck` ジョブを追加（3.11 x86／pyright）
+- lint（ruff）は包括パイプラインにも advisory で追加（`lint` ジョブ）
 - 日本語版フルビルド・配布系: `.github/workflows/testAndPublish.yml`
 - ローカル最小ビルド例: `scons --help` を確認し、通常は `scons source dist launcher --all-cores`
 - 単体/システムテスト: `ci/scripts/tests/unitTests.ps1`、`ci/scripts/tests/systemTests.ps1`

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -2,9 +2,9 @@
 
 目的: 本家版との差分を最小化しながら、順序立てて基盤整合 → 言語/依存更新 → 64bit 対応を進める。
 
-## 2026.1jp の先 — 目標状態（2026–2027）
+## 2026.1jp 以後の目標
 
-日本語版を小さく安定に保ち、本家版追従のコストとリスクを継続的に低減する。
+日本語版を小さく安定に保ち、本家版追従のコストとリスクを継続的に低減する。SConsを唯一のビルド・オーケストレーターにする。
 
 - 本家版との差分（最小化）
   - 目標: 日本語版固有差分は「専用ディレクトリ＋パッチ最小」。恒常的な差分ファイル数 ≤ 50、差分行数 ≤ 2,000 を維持。
@@ -34,23 +34,18 @@
   - 可能な限り本家版に合わせる
   - 32bit版 NVDA 日本語版は本家版と同様に 2025.3 系で終了
 
-  - \.python-versions を 3.11 x86 のみに固定（完了）
+## Phase 1 : 基盤整合と安定化
 
-  - Lint（ruff）ジョブ追加・安定化
-  - testAndPublish の主要ジョブを段階的に windows-2025 へ（後述: ランナー移行計画）
-  - jptools/setupMiscDepsJp.cmd の 7z ラウンドトリップ除去（Python/SCons化）
-  - SCons キャッシュ/引数の整合（ci/scripts/setSconsArgs.ps1 準拠）
-  - ユニット/必要最小のシステムテストを安定緑（installerタグは除外可）
+- Windows 32bit / Python 3.11 x86 を基盤とし、本家版との差分を最小化
+- \.python-versions を 3.11 x86 のみに固定
+- CI を SCons で成立させ、.cmd 経由を可能な範囲で排除
+- SCons キャッシュ/引数の整合（ci/scripts/setSconsArgs.ps1 準拠）
+- Lint（ruff）ジョブ追加・安定化
+- 7z ラウンドトリップ除去（Python化）
+- ユニット/必要最小のシステムテストを安定して通す（installerタグは除外可）
+- testAndPublish の主要ジョブを windows-2025 へ（後述: ランナー移行計画）
 
-## 既知の懸念（メモ）
-
-- Python 3.13 への移行と x64 対応が、fast-diff-match-patch（DMP）依存の配布状況により同時対応になりうる。
-  - 対応方針（今は実装せず記録のみ）
-    - DMP 読み込み失敗時は difflib へ自動フォールバック（コード側で遅延 import/try-except）
-    - CI では 3.13 x64 を先行検証、3.13 x86 は typeCheck/lint のみ等で段階導入
-  - Phase 1 完了時点で再評価し、必要なら Phase 2 の計画に反映
-
-## Phase 2 — Python 3.13 対応（Part of #530）
+## Phase 2 : Python 3.13 対応（Part of #530）
 
 - Scope
   - 3.13 x64 を必須とし、3.11 x86 はEOLまで保守
@@ -59,7 +54,7 @@
   - 依存互換性の確認・ピン更新（wxPython, brlapi など）
   - .python-versions に 3.13 を追加（3.11 と併存）
   - CI ジョブ分割（typeCheck / unit / docs / packaging）を本家版構成へ近づける
- - Exit
+- Exit
   - 3.13 x64 が安定して緑、3.11 x86 は EOL（2025.3）まで緑を維持
 - 補足（運用）
   - 目的: x64 を既定化に向け安定、3.13 を実用レベルへ（配布は段階導入）
@@ -67,7 +62,15 @@
   - DMP フォールバック: fast-diff-match-patch が利用不可の場合は difflib へ自動退避
   - 主要 JP アドオン（jtalk/kgs）を x64 で起動確認（任意）
 
-## Phase 3 — x64 ビルド対応（Part of #530）
+### 既知の懸念
+
+- Python 3.13 への移行と x64 対応が、fast-diff-match-patch（DMP）依存の配布状況により同時対応になりうる。
+  - 対応方針（今は実装せず記録のみ）
+    - DMP 読み込み失敗時は difflib へ自動フォールバック（コード側で遅延 import/try-except）
+    - CI では 3.13 x64 を先行検証、3.13 x86 は typeCheck/lint のみ等で段階導入
+  - Phase 1 完了時点で再評価し、必要なら Phase 2 の計画に反映
+
+## Phase 3 : x64 ビルド対応（Part of #530）
 
 - Scope
   - x64（将来 arm64）ビルドの追加、移行パス検証
@@ -124,5 +127,3 @@
 - JP Docs Hub: projectDocs/jp/README.md
 - 本家版開発環境: projectDocs/dev/createDevEnvironment.md
 - エージェント向け: AGENTS.md
-
-

--- a/readme-nvdajp.md
+++ b/readme-nvdajp.md
@@ -16,6 +16,7 @@ NVDA 日本語版の概要と最短手順を示します。詳細は JP Docs Hub
 
 ## CI
 - 型チェック（本家版寄せ・安全導入）: `.github/workflows/nvbeta-typecheck-311x86.yml`
+- `testAndPublish.yml` にも `typeCheck` ジョブを追加（3.11 x86／pyright）
 - 日本語版の包括パイプライン: `.github/workflows/testAndPublish.yml`
 
 ## リリース


### PR DESCRIPTION
目的
- 本家寄りCIへの整合を進めつつ、Python 3.11 x86 を維持（Step 1 / Refs #539）。

変更点
- testAndPublish に 	ypeCheck ジョブを追加（windows-2025 / Python 3.11 x86 / uv + pyright）。
- llTestsPass の 
eeds に 	ypeCheck を追加（型チェックをゲート化）。
- advisory の lint ジョブを追加（uff format --check / uff check を continue-on-error: true）。
- JP Docs Hub に lint advisory 追加の旨を追記。

非破壊／セキュリティ
- 秘密情報は使用しない、署名・配布は実施しない（AGENTS.md 方針に準拠）。
- 既存の専用 typeCheck ワークフロー（nvbeta-typecheck-311x86.yml）は当面維持し、安定後に段階統合を検討。

今後
- lint を一定期間観測後、ゲート統合の可否を判断。
- 7z 依存の残存箇所（例: buildControllerClient.cmd）を段階的に純Python/PowerShellへ置換。