### PR TITLE
Phase 1: Replace 7z in symbols packaging; add Python packer for controller client (refs #539)

### DIFF
--- a/ci/scripts/buildSymbolStore.ps1
+++ b/ci/scripts/buildSymbolStore.ps1
@@ -18,4 +18,12 @@ foreach ($syms in
 }
 
 Set-Location symbols
-7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
+# Create symbols.zip without external 7z dependency
+$dest = Join-Path (Resolve-Path ..\output) 'symbols.zip'
+if (Test-Path $dest) { Remove-Item -Force $dest }
+$files = Get-ChildItem -Recurse -File -Include *.dl_,*.ex_,*.pd_ | Select-Object -ExpandProperty FullName
+if ($files -and $files.Count -gt 0) {
+    Compress-Archive -Path $files -DestinationPath $dest
+} else {
+    Write-Host "No symbol files (*.dl_, *.ex_, *.pd_) found to archive."
+}

--- a/jptools/buildControllerClient.cmd
+++ b/jptools/buildControllerClient.cmd
@@ -22,7 +22,14 @@ copy ..\..\build\arm64\client\nvdaControllerClient.exp arm64
 copy ..\..\build\arm64\client\nvdaControllerClient.lib arm64
 
 SET OUTFILE=..\..\output\nvda_%VERSION%_controllerClientJp.zip
-del /Q %OUTFILE%
-7z a %OUTFILE% arm64 examples x64 x86 license.txt readme.html readmejp.txt
+IF EXIST "%OUTFILE%" DEL /Q "%OUTFILE%"
+REM Prefer Python-based packer to avoid 7z dependency
+py -3 ..\pack_controller_client.py --version %VERSION% --client-root . --output "%OUTFILE%"
+IF EXIST "%OUTFILE%" GOTO :pack_done
+python ..\pack_controller_client.py --version %VERSION% --client-root . --output "%OUTFILE%"
+IF EXIST "%OUTFILE%" GOTO :pack_done
+REM Fallback to 7z if Python packer is not available
+7z a "%OUTFILE%" arm64 examples x64 x86 license.txt readme.html readmejp.txt
+:pack_done
 cd ..
 cd ..

--- a/jptools/pack_controller_client.py
+++ b/jptools/pack_controller_client.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+from pathlib import Path
+from zipfile import ZipFile, ZIP_DEFLATED
+
+
+def add_path(zipf: ZipFile, base_dir: Path, path: Path) -> None:
+    if path.is_dir():
+        for p in path.rglob('*'):
+            if p.is_file():
+                arcname = p.relative_to(base_dir).as_posix()
+                zipf.write(p, arcname)
+    else:
+        arcname = path.relative_to(base_dir).as_posix()
+        zipf.write(path, arcname)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pack NVDA controller client (no 7z)")
+    parser.add_argument('--version', default=os.environ.get('VERSION'), required=False,
+                        help='Version string used for output filename if --output is not given')
+    parser.add_argument('--client-root', default=None,
+                        help='Path to nvdajpClient root (defaults to jptools/nvdajpClient)')
+    parser.add_argument('--output', default=None,
+                        help='Output zip path (defaults to output/nvda_<version>_controllerClientJp.zip)')
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+    client_root = Path(args.client_root) if args.client_root else (script_dir / 'nvdajpClient')
+    client_root = client_root.resolve()
+
+    if not client_root.exists():
+        raise SystemExit(f"client root not found: {client_root}")
+
+    if args.output:
+        out_path = Path(args.output)
+    else:
+        version = args.version or 'local'
+        out_path = repo_root / 'output' / f'nvda_{version}_controllerClientJp.zip'
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    targets = [
+        'arm64', 'examples', 'x64', 'x86',
+        'license.txt', 'readme.html', 'readmejp.txt',
+    ]
+
+    with ZipFile(out_path, 'w', compression=ZIP_DEFLATED) as zf:
+        for t in targets:
+            p = (client_root / t)
+            if not p.exists():
+                # Skip missing optional targets silently to mirror prior behavior
+                continue
+            add_path(zf, client_root, p)
+
+    print(out_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())
+


### PR DESCRIPTION
目的
- Step 1（本家寄せ + 3.11 x86 維持）の方針に沿って、7z 依存を安全に縮小。

変更点
- ci/scripts/buildSymbolStore.ps1: 7z → Compress-Archive（標準PowerShell）で symbols.zip を作成。
- jptools/buildControllerClient.cmd: Pythonパッカーを優先し、作成に成功したら終了。失敗時のみ 7z にフォールバック。
- jptools/pack_controller_client.py: コントローラクライアントのZipを純Python(zipfile)で生成する新規ツールを追加。

互換性/影響
- CI の挙動に変更なし（symbols.zip の生成のみ内部実装がPowerShell標準に）。
- buildControllerClient.cmd は Python 利用環境で 7z 不要に。7z が無い環境でもフォールバックにより破綻しません。

今後（別PR）
- 7z を使う残存 .cmd（signed_output_pack/selfcert_pack_dist, pack_*.cmd）を段階的に置換（純Python/PowerShell化、またはSConsターゲット化）。
- 置換後に 7z 前提の記述を削減（JP Docs/legacy ドキュメントの整備）。

Refs: #539