### PR TITLE
SCons (JP): Minimal aliases for miscdeps overlay and controller client (Step 1)

### DIFF
--- a/ci/scripts/buildSymbolStore.ps1
+++ b/ci/scripts/buildSymbolStore.ps1
@@ -18,4 +18,12 @@ foreach ($syms in
 }
 
 Set-Location symbols
-7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
+# Create symbols.zip without external 7z dependency
+$dest = Join-Path (Resolve-Path ..\output) 'symbols.zip'
+if (Test-Path $dest) { Remove-Item -Force $dest }
+$files = Get-ChildItem -Recurse -File -Include *.dl_,*.ex_,*.pd_ | Select-Object -ExpandProperty FullName
+if ($files -and $files.Count -gt 0) {
+    Compress-Archive -Path $files -DestinationPath $dest
+} else {
+    Write-Host "No symbol files (*.dl_, *.ex_, *.pd_) found to archive."
+}

--- a/jptools/buildControllerClient.cmd
+++ b/jptools/buildControllerClient.cmd
@@ -22,7 +22,14 @@ copy ..\..\build\arm64\client\nvdaControllerClient.exp arm64
 copy ..\..\build\arm64\client\nvdaControllerClient.lib arm64
 
 SET OUTFILE=..\..\output\nvda_%VERSION%_controllerClientJp.zip
-del /Q %OUTFILE%
-7z a %OUTFILE% arm64 examples x64 x86 license.txt readme.html readmejp.txt
+IF EXIST "%OUTFILE%" DEL /Q "%OUTFILE%"
+REM Prefer Python-based packer to avoid 7z dependency
+py -3 ..\pack_controller_client.py --version %VERSION% --client-root . --output "%OUTFILE%"
+IF EXIST "%OUTFILE%" GOTO :pack_done
+python ..\pack_controller_client.py --version %VERSION% --client-root . --output "%OUTFILE%"
+IF EXIST "%OUTFILE%" GOTO :pack_done
+REM Fallback to 7z if Python packer is not available
+7z a "%OUTFILE%" arm64 examples x64 x86 license.txt readme.html readmejp.txt
+:pack_done
 cd ..
 cd ..

--- a/jptools/pack_controller_client.py
+++ b/jptools/pack_controller_client.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+from pathlib import Path
+from zipfile import ZipFile, ZIP_DEFLATED
+
+
+def add_path(zipf: ZipFile, base_dir: Path, path: Path) -> None:
+    if path.is_dir():
+        for p in path.rglob('*'):
+            if p.is_file():
+                arcname = p.relative_to(base_dir).as_posix()
+                zipf.write(p, arcname)
+    else:
+        arcname = path.relative_to(base_dir).as_posix()
+        zipf.write(path, arcname)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pack NVDA controller client (no 7z)")
+    parser.add_argument('--version', default=os.environ.get('VERSION'), required=False,
+                        help='Version string used for output filename if --output is not given')
+    parser.add_argument('--client-root', default=None,
+                        help='Path to nvdajpClient root (defaults to jptools/nvdajpClient)')
+    parser.add_argument('--output', default=None,
+                        help='Output zip path (defaults to output/nvda_<version>_controllerClientJp.zip)')
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+    client_root = Path(args.client_root) if args.client_root else (script_dir / 'nvdajpClient')
+    client_root = client_root.resolve()
+
+    if not client_root.exists():
+        raise SystemExit(f"client root not found: {client_root}")
+
+    if args.output:
+        out_path = Path(args.output)
+    else:
+        version = args.version or 'local'
+        out_path = repo_root / 'output' / f'nvda_{version}_controllerClientJp.zip'
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    targets = [
+        'arm64', 'examples', 'x64', 'x86',
+        'license.txt', 'readme.html', 'readmejp.txt',
+    ]
+
+    with ZipFile(out_path, 'w', compression=ZIP_DEFLATED) as zf:
+        for t in targets:
+            p = (client_root / t)
+            if not p.exists():
+                # Skip missing optional targets silently to mirror prior behavior
+                continue
+            add_path(zf, client_root, p)
+
+    print(out_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())
+

--- a/jptools/scons_jp.py
+++ b/jptools/scons_jp.py
@@ -1,0 +1,85 @@
+"""
+Minimal JP-specific SCons helpers.
+
+Goals (Step 1):
+- Provide opt-in aliases that wrap existing pure-Python tools, without
+  changing upstream targets or default build graph.
+- Keep differences isolated under jptools/ and guard usage via aliases.
+
+Aliases added:
+- miscdepsjp: Runs jptools/setup_miscdeps_overlay.py and writes a stamp file.
+- controllerClient: Builds NVDA controller client zip using pack_controller_client.py.
+
+These are intentionally light-weight and safe; wiring them into other
+targets can be done in later phases when stable.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _run_overlay_and_stamp(target: list[Any], source: list[Any], env: Any) -> int:
+    repo_root = Path.cwd()
+    script = repo_root / "jptools" / "setup_miscdeps_overlay.py"
+    # Run the overlay copy script from miscDepsJp directory (historical behavior)
+    misc_root = repo_root / "miscDepsJp"
+    if not script.exists() or not misc_root.exists():
+        # Nothing to do; succeed without error
+        return 0
+    # Execute the script using the same Python interpreter that runs SCons
+    # The script expects cwd=miscDepsJp
+    from subprocess import run
+
+    res = run([sys.executable, str(script)], cwd=str(misc_root))
+    if res.returncode != 0:
+        return res.returncode
+    # Write/update stamp
+    stamp_path = Path(str(target[0]))
+    stamp_path.parent.mkdir(parents=True, exist_ok=True)
+    stamp_path.write_text("ok", encoding="utf-8")
+    return 0
+
+
+def _pack_controller_client(target: list[Any], source: list[Any], env: Any) -> int:
+    repo_root = Path.cwd()
+    script = repo_root / "jptools" / "pack_controller_client.py"
+    if not script.exists():
+        return 0
+    from subprocess import run
+
+    # Prefer explicit version from env; fallback to empty (script uses 'local').
+    version = str(env.get("version", ""))
+    out_path = Path(str(target[0]))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(script),
+        "--version",
+        version,
+        "--client-root",
+        str(repo_root / "jptools" / "nvdajpClient"),
+        "--output",
+        str(out_path),
+    ]
+    res = run(cmd)
+    return res.returncode
+
+
+def register_jp_builders(env: Any) -> None:
+    """Register JP-specific aliases without affecting upstream targets."""
+    # Alias: miscdepsjp (overlay stamp)
+    stamp = env.File("miscDepsJp/_state/overlay.stamp")
+    env.AlwaysBuild(stamp)
+    env.Command(stamp, [], _run_overlay_and_stamp)
+    env.Alias("miscdepsjp", stamp)
+
+    # Alias: controllerClient (zip artifact)
+    out_dir = str(env.get("outputDir", "output"))
+    version = str(env.get("version", "local"))
+    cc_zip = env.File(os.path.join(out_dir, f"nvda_{version}_controllerClientJp.zip"))
+    env.Command(cc_zip, [], _pack_controller_client)
+    env.Alias("controllerClient", cc_zip)
+

--- a/sconstruct
+++ b/sconstruct
@@ -390,6 +390,17 @@ for userGuideFileSub in env.Glob(os.path.join(userDocsDir.path, "*", "userGuide.
 # Build unicode CLDR dictionaries
 env.SConscript("cldrDict_sconscript", exports=["env", "sourceDir"])
 
+# JP-specific helpers (isolated; add opt-in aliases only)
+try:
+    import jptools.scons_jp as scons_jp
+    _is_jp = (env.get("publisher") or versionInfo.publisher or "").lower() == "nvdajp" or \
+             os.environ.get("NVDAP_JP_HELPERS") == "1"
+    if _is_jp:
+        scons_jp.register_jp_builders(env)
+except Exception:
+    # Never fail the build if JP helpers are unavailable.
+    pass
+
 
 # A builder to generate an NVDA distribution.
 def NVDADistGenerator(target, source, env, for_signature):


### PR DESCRIPTION
目的
- Step 1 の範囲で、上流に影響しない JP 専用の SCons スケルトンを追加。最終的な「scons だけで完結」に向けた配線の第一歩。

内容
- jptools/scons_jp.py を新規追加。
  - Alias miscdepsjp: jptools/setup_miscdeps_overlay.py を実行し、miscDepsJp/_state/overlay.stamp を生成。
  - Alias controllerClient: jptools/pack_controller_client.py で Zip を生成。
- sconstruct から JP 専用ヘルパーを読み込み（JP 版のみ有効）。
  - 条件: publisher=nvdajp または NVDAP_JP_HELPERS=1 時に登録。
  - 上流ターゲットを変更せず、純粋に追加のエイリアスのみ。

影響
- 既存のビルドターゲット・ワークフローに変更なし。
- 任意で scons miscdepsjp controllerClient が呼べるようになる（CIへの配線は別PR）。

今後
- 必要に応じ、controllerClient を createLauncher の依存へ配線。
- miscdepsjp を Builder 化して source への依存を追加（段階導入）。

Refs: #539