### PR TITLE
CI: Step1 follow-ups (unit/license/translator)

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -167,7 +167,14 @@ jobs:
         echo Building with args: %sconsArgs% (USE_PY_OVERLAY_COPY=%USE_PY_OVERLAY_COPY%)
         REM Apply JP overlay via SCons alias (miscdepsjp)
         scons miscdepsjp %sconsArgs%
-        if errorlevel 1 exit /b %errorlevel%
+if errorlevel 1 (
+  echo ::warning:: scons alias 'miscdepsjp' unavailable; falling back to Python overlay
+  pushd miscDepsJp
+  py -3 ..\jptools\setup_miscdeps_overlay.py || python ..\jptools\setup_miscdeps_overlay.py
+  if errorlevel 1 exit /b %errorlevel%
+  popd
+)
+
         REM Build via SCons (replicates nonCertAllBuild.cmd)
         scons source %sconsArgs%
         if errorlevel 1 exit /b %errorlevel%
@@ -858,7 +865,6 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber \
             output/nvda*.exe#Installer
-
 
 
 

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -246,7 +246,6 @@ jobs:
         # On GitHub Actions, avoid installer tests (unsigned build). Run startup/shutdown only.
         INCLUDE_SYSTEM_TEST_TAGS: startupShutdown
         INCLUDE_SYSTEM_TEST_TAGS: startupShutdown
-
     - name: Check test results
       run: |
         if ($env:testFailExitCode -and $env:testFailExitCode -ne "0") {

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -161,19 +161,19 @@ jobs:
       shell: powershell
 
     - name: Build NVDA Japanese version (SCons + JP alias)
-      run: |
+      run: |2
         set USE_PY_OVERLAY_COPY=1
         set sconsArgs=version_build=%GITHUB_RUN_NUMBER% --all-cores publisher=%PUBLISHER% version=%VERSION% updateVersionType=%UPDATEVERSIONTYPE% release=%RELEASE%
         echo Building with args: %sconsArgs% (USE_PY_OVERLAY_COPY=%USE_PY_OVERLAY_COPY%)
         REM Apply JP overlay via SCons alias (miscdepsjp)
         scons miscdepsjp %sconsArgs%
-if errorlevel 1 (
-  echo ::warning:: scons alias 'miscdepsjp' unavailable; falling back to Python overlay
-  pushd miscDepsJp
+        if errorlevel 1 (
+          echo ::warning:: scons alias 'miscdepsjp' unavailable; falling back to Python overlay
+          pushd miscDepsJp
   py -3 ..\jptools\setup_miscdeps_overlay.py || python ..\jptools\setup_miscdeps_overlay.py
-  if errorlevel 1 exit /b %errorlevel%
-  popd
-)
+          if errorlevel 1 exit /b %errorlevel%
+          popd
+        )
 
         REM Build via SCons (replicates nonCertAllBuild.cmd)
         scons source %sconsArgs%

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -161,7 +161,7 @@ jobs:
       shell: powershell
 
     - name: Build NVDA Japanese version (SCons + JP alias)
-      run: |2
+      run: |
         set USE_PY_OVERLAY_COPY=1
         set sconsArgs=version_build=%GITHUB_RUN_NUMBER% --all-cores publisher=%PUBLISHER% version=%VERSION% updateVersionType=%UPDATEVERSIONTYPE% release=%RELEASE%
         echo Building with args: %sconsArgs% (USE_PY_OVERLAY_COPY=%USE_PY_OVERLAY_COPY%)
@@ -170,7 +170,7 @@ jobs:
         if errorlevel 1 (
           echo ::warning:: scons alias 'miscdepsjp' unavailable; falling back to Python overlay
           pushd miscDepsJp
-  py -3 ..\jptools\setup_miscdeps_overlay.py || python ..\jptools\setup_miscdeps_overlay.py
+          py -3 ..\jptools\setup_miscdeps_overlay.py || python ..\jptools\setup_miscdeps_overlay.py
           if errorlevel 1 exit /b %errorlevel%
           popd
         )
@@ -812,6 +812,7 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber \
             output/nvda*.exe#Installer
+
 
 
 

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -245,7 +245,6 @@ jobs:
         nvdaLauncherDir: ${{ github.workspace }}\output
         # On GitHub Actions, avoid installer tests (unsigned build). Run startup/shutdown only.
         INCLUDE_SYSTEM_TEST_TAGS: startupShutdown
-        INCLUDE_SYSTEM_TEST_TAGS: startupShutdown
     - name: Check test results
       run: |
         if ($env:testFailExitCode -and $env:testFailExitCode -ne "0") {

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -160,13 +160,23 @@ jobs:
         echo "API Back Compat To: $apiCompatTo"
       shell: powershell
 
-    - name: Build NVDA Japanese version
+    - name: Build NVDA Japanese version (no .cmd wrapper)
       run: |
         set USE_PY_OVERLAY_COPY=1
-        set sconsArgs=version_build=%GITHUB_RUN_NUMBER% --all-cores
-        echo Building with args: %sconsArgs%
+        set sconsArgs=version_build=%GITHUB_RUN_NUMBER% --all-cores publisher=%PUBLISHER% version=%VERSION% updateVersionType=%UPDATEVERSIONTYPE% release=%RELEASE%
         echo Building with args: %sconsArgs% (USE_PY_OVERLAY_COPY=%USE_PY_OVERLAY_COPY%)
-        call jptools\nonCertAllBuild.cmd %sconsArgs%
+        REM Apply miscDepsJp overlay using pure Python (fallback to python if py -3 not available)
+        pushd miscDepsJp
+        py -3 ..\jptools\setup_miscdeps_overlay.py || python ..\jptools\setup_miscdeps_overlay.py
+        popd
+        REM Build via SCons (replicates nonCertAllBuild.cmd)
+        scons source %sconsArgs%
+        if errorlevel 1 exit /b %errorlevel%
+        scons user_docs %sconsArgs%
+        if errorlevel 1 exit /b %errorlevel%
+        scons dist %sconsArgs%
+        if errorlevel 1 exit /b %errorlevel%
+        scons launcher %sconsArgs%
       shell: cmd
 
     - name: Build Japanese addons (no 7z)

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -295,6 +295,9 @@ jobs:
         architecture: 'x86'
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
+    - name: Prepare test directories
+      shell: pwsh
+      run: ci/scripts/tests/beforeTests.ps1
     - name: Check comments for translators
       run: ci/scripts/tests/translationCheck.ps1
     - name: Upload artifact
@@ -302,7 +305,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: pot-check-${{ github.run_number }}
-        path: testOutput/translationCheck.txt
+        path: testOutput/translationCheckResults.log
 
   licenseCheck:
     name: Check license compatibility of dependencies
@@ -322,8 +325,17 @@ jobs:
         architecture: 'x86'
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
+    - name: Prepare test directories
+      shell: pwsh
+      run: ci/scripts/tests/beforeTests.ps1
     - name: License check
       run: ci/scripts/tests/licenseCheck.ps1
+    - name: Upload license check results
+      if: ${{ success() || failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: license-check-${{ github.run_number }}
+        path: testOutput/license/licenseCheckResults.md
 
   unitTests:
     name: Run unit tests
@@ -343,10 +355,13 @@ jobs:
         architecture: 'x86'
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
+    - name: Prepare test directories
+      shell: pwsh
+      run: ci/scripts/tests/beforeTests.ps1
     - name: Run unit tests
       run: ci/scripts/tests/unitTests.ps1
     - name: Replace relative paths in unit test results
-      if: ${{ failure() }}
+      if: ${{ failure() && hashFiles('testOutput/unit/unitTests.xml') != '' }}
       # Junit reports fail on these
       shell: bash
       run: sed -i 's|file="..\\|file="|g' testOutput/unit/unitTests.xml

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -160,15 +160,14 @@ jobs:
         echo "API Back Compat To: $apiCompatTo"
       shell: powershell
 
-    - name: Build NVDA Japanese version (no .cmd wrapper)
+    - name: Build NVDA Japanese version (SCons + JP alias)
       run: |
         set USE_PY_OVERLAY_COPY=1
         set sconsArgs=version_build=%GITHUB_RUN_NUMBER% --all-cores publisher=%PUBLISHER% version=%VERSION% updateVersionType=%UPDATEVERSIONTYPE% release=%RELEASE%
         echo Building with args: %sconsArgs% (USE_PY_OVERLAY_COPY=%USE_PY_OVERLAY_COPY%)
-        REM Apply miscDepsJp overlay using pure Python (fallback to python if py -3 not available)
-        pushd miscDepsJp
-        py -3 ..\jptools\setup_miscdeps_overlay.py || python ..\jptools\setup_miscdeps_overlay.py
-        popd
+        REM Apply JP overlay via SCons alias (miscdepsjp)
+        scons miscdepsjp %sconsArgs%
+        if errorlevel 1 exit /b %errorlevel%
         REM Build via SCons (replicates nonCertAllBuild.cmd)
         scons source %sconsArgs%
         if errorlevel 1 exit /b %errorlevel%

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -221,35 +221,9 @@ if errorlevel 1 (
       shell: powershell
 
     - name: Install NVDA for testing
-      run: |
-        # Discover the built installer rather than assuming the exact name.
-        $candidate = Get-ChildItem -Path .\output -Filter "nvda_*.exe" -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-        if (-not $candidate) {
-          echo "::error::No NVDA installer found under .\\output. Listing directory for diagnostics..."
-          Get-ChildItem -Path .\output -Force -ErrorAction SilentlyContinue | Format-List | Out-String -Width 2000
-          exit 1
-        }
-        $nvdaLauncherFile = $candidate.FullName
-        echo "nvdaLauncherFile=$nvdaLauncherFile" >> $env:GITHUB_ENV
-        echo "NVDALauncherFile: $nvdaLauncherFile"
-
-        $outputDir = $(resolve-path .\testOutput)
-        $installerLogFilePath = "$outputDir\nvda_install.log"
-        $installerProcess = start-process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -passthru
-        
-        try {
-          $installerProcess | wait-process -Timeout 180 -ErrorAction Stop
-          $errorCode = $installerProcess.ExitCode
-        } catch {
-          echo "::error::NVDA installer process timed out"
-          $errorCode = 1
-        }
-        
-        if($errorCode -ne 0) { 
-          echo "::error::NVDA installation failed with exit code $errorCode"
-          exit $errorCode 
-        }
-      shell: powershell
+      run: ci/scripts/installNVDA.ps1
+      env:
+        nvdaLauncherDir: ${{ github.workspace }}\output
 
     - name: Run unit tests
       run: |
@@ -266,38 +240,11 @@ if errorlevel 1 (
       shell: powershell
 
     - name: Run system tests
-      run: |
-        $testOutput = (Resolve-Path .\testOutput\)
-        $systemTestOutput = (Resolve-Path "$testOutput\system")
-        
-        $verboseDebugLogging = if ($env:VERBOSE_SYSTEM_TEST_LOGGING) { "True" } else { "" }
-        # Skip symbolPronunciation tests due to timeout issues in Japanese version
-        $tagsForTest = "installer startupShutdown"
-        
-        if ($env:INCLUDE_SYSTEM_TEST_TAGS) {
-          if ($env:INCLUDE_SYSTEM_TEST_TAGS -eq "excluded_from_build") {
-            echo "::notice::System tests skipped"
-            return
-          }
-          $tagsForTest = $env:INCLUDE_SYSTEM_TEST_TAGS
-        }
-        
-        $tagsForTestArray = -split $tagsForTest
-        $includeTags = $tagsForTestArray | ForEach-Object { "--include", $_ }
-        
-        .\runsystemtests.bat --variable whichNVDA:installed --variable installDir:"$env:nvdaLauncherFile" --variable verboseDebugLogging:"$verboseDebugLogging" @includeTags
-        
-        if($LastExitCode -ne 0) {
-          echo "testFailExitCode=$LastExitCode" >> $env:GITHUB_ENV
-          echo "::error::System tests failed (tags: $tagsForTest)"
-        } else {
-          echo "::notice::System tests passed (tags: $tagsForTest)"
-        }
-        
-        Compress-Archive -Path "$systemTestOutput\*" -DestinationPath "$testOutput\systemTestResult.zip"
-      shell: powershell
+      run: ci/scripts/tests/systemTests.ps1
       env:
+        nvdaLauncherDir: ${{ github.workspace }}\output
         # On GitHub Actions, avoid installer tests (unsigned build). Run startup/shutdown only.
+        INCLUDE_SYSTEM_TEST_TAGS: startupShutdown
         INCLUDE_SYSTEM_TEST_TAGS: startupShutdown
 
     - name: Check test results

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -207,53 +207,8 @@ jobs:
         call jpchar\tests.cmd
       shell: cmd
 
-    - name: Prepare for system tests
-      run: |
-        # Create test output directories using the same script as upstream
-        ci/scripts/tests/beforeTests.ps1
-        
-        # Start Chrome for system tests
-        $chromeStartArgsString = $(py tests/system/libraries/_chromeArgs.py)
-        $chromeStartArgsArray = $chromeStartArgsString -split " "
-        cmd /c start /min $chromeStartArgsArray
-        
-        echo "testFailExitCode=0" >> $env:GITHUB_ENV
-      shell: powershell
-
-    - name: Install NVDA for testing
-      run: ci/scripts/installNVDA.ps1
-      env:
-        nvdaLauncherDir: ${{ github.workspace }}\output
-
-    - name: Run unit tests
-      run: |
-        $outDir = (Resolve-Path .\testOutput\unit\)
-        $unitTestsXml = "$outDir\unitTests.xml"
-        .\rununittests.bat --output-file "$unitTestsXml" -v
-        
-        if($LastExitCode -ne 0) {
-          echo "testFailExitCode=$LastExitCode" >> $env:GITHUB_ENV
-          echo "::error::Unit tests failed"
-        } else {
-          echo "::notice::Unit tests passed"
-        }
-      shell: powershell
-
-    - name: Run system tests
-      run: ci/scripts/tests/systemTests.ps1
-      env:
-        nvdaLauncherDir: ${{ github.workspace }}\output
-        # On GitHub Actions, avoid installer tests (unsigned build). Run startup/shutdown only.
-        INCLUDE_SYSTEM_TEST_TAGS: startupShutdown
-    - name: Check test results
-      run: |
-        if ($env:testFailExitCode -and $env:testFailExitCode -ne "0") {
-          echo "::error::Tests failed with exit code $env:testFailExitCode"
-          exit $env:testFailExitCode
-        } else {
-          echo "::notice::All tests passed"
-        }
-      shell: powershell
+    # Tests are executed in dedicated jobs (unitTests/systemTests). Skip install/tests here to avoid duplicate runs and
+    # ensure the launcher built in createLauncher is used consistently.
 
     - name: Cache scons build
       uses: actions/cache/save@v4

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -497,6 +497,9 @@ jobs:
       with:
         name: NVDA launcher
         path: output
+    - name: Prepare test directories
+      shell: pwsh
+      run: ci/scripts/tests/beforeTests.ps1
     - name: Install NVDA
       run: ci/scripts/installNVDA.ps1
       env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@
 
 ## CI とブランチ
 - PR の base は通常 `betajp`
+- `betajp` は日本語版の安定ブランチ。直接 push・試行錯誤は禁止。作業は必ずトピックブランチ→Pull Request（PR）で行うこと。
+- ブランチ保護（推奨）: `betajp` に対して PR レビュー必須＋ステータスチェック必須（`allTestsPass`、`NVAccess Beta Aligned TypeCheck (3.11 x86)` など）。
+- CIでの配布系ジョブ（release 等）はデフォルト無効（フラグや条件で明示的に有効化）とし、Secrets を必要とする運用は避ける。
 - 型チェックのみの本家版寄せワークフロー: `.github/workflows/nvbeta-typecheck-311x86.yml`
 - 日本語版の包括的ワークフロー: `.github/workflows/testAndPublish.yml`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,30 +3,53 @@
 このファイルは、リポジトリ内で自動化エージェント／スクリプトが守る最小限のルールと最短手順を示します。詳細な説明は人間向けドキュメントを参照してください。
 
 ## スコープ（Step 1）
+
 - 目的: 3.11 x86 を維持したまま「本家版寄りのCI/ビルド基盤」に整合
 - 除外: x64/arm64 切替、Java Access Bridge 64bit、Python 3.13 への移行
 - 関連: Issue #539（Step 1）、Issue #530（本家版 2026.1 マージ全体）
 
 ## 禁則と優先
+
 - 破壊的操作を避ける（履歴の書換は明示指示時のみ）
 - 本家版との差分は最小化し、差分は明示的な場所に集約
 - 可能な限り SCons / 純 Python を優先（.cmd / 7z / nmake 依存は削減）
 - コードサイニング/配布は CI で行わない（Secrets を使用しない）。正式リリースはローカルで実施
 
 ## 最短コマンド
+
 - 型チェック: `ci/scripts/tests/typeCheck.ps1`（Pyright）
 - Lint（推奨）: `uv run ruff format --check && uv run ruff check`
 - ビルド例: `scons source dist launcher --all-cores`
 
 ## CI とブランチ
+
 - PR の base は通常 `betajp`
 - `betajp` は日本語版の安定ブランチ。直接 push・試行錯誤は禁止。作業は必ずトピックブランチ→Pull Request（PR）で行うこと。
 - ブランチ保護（推奨）: `betajp` に対して PR レビュー必須＋ステータスチェック必須（`allTestsPass`、`NVAccess Beta Aligned TypeCheck (3.11 x86)` など）。
 - CIでの配布系ジョブ（release 等）はデフォルト無効（フラグや条件で明示的に有効化）とし、Secrets を必要とする運用は避ける。
+
+## testAndPublish の上流追従（方針）
+
+- 目的: 本家 `testAndPublish.yml` をそのまま取り込み、JP 固有は最小パッチの注入に限定する。
+- 原則:
+  - JP 固有の前処理・後処理は `ci/scripts/` のスクリプトへ寄せる（YAML にはスクリプト呼び出しの1行だけ残す）。
+  - YAML 側の JP 追加は `# BEGIN JP PATCH` / `# END JP PATCH` のマーカーで囲う。
+  - 上流更新時はファイル丸ごと置換 → JP パッチ（最小）を再適用。
+- 実務メモ:
+  - `beforeTests.ps1` で `testOutput/` 配下を作成。
+  - installer/system tests は共通スクリプト（`installNVDA.ps1` / `tests/systemTests.ps1`）。
+  - 単体テストは `rununittests.bat` で `uv --group dev --group unit-tests` を使用（`miscDeps` を sys.path に含める）。
+
+## Actions 運用
+
+- 監視: `gh run list -w .github/workflows/testAndPublish.yml -b betajp -L 3`
+- 失敗調査: `gh run view <runId> --log`、またはチェックランのアノテーションを参照。
+- 再実行: `gh run rerun <runId> --failed`
 - 型チェックのみの本家版寄せワークフロー: `.github/workflows/nvbeta-typecheck-311x86.yml`
 - 日本語版の包括的ワークフロー: `.github/workflows/testAndPublish.yml`
 
 ## 参照
+
 - 人間向けハブ: `projectDocs/jp/README.md`
 - 本家版の開発環境: `projectDocs/dev/createDevEnvironment.md`
 - 日本語版の概要: `readme-nvdajp.md`

--- a/ci/scripts/tests/licenseCheck.ps1
+++ b/ci/scripts/tests/licenseCheck.ps1
@@ -1,3 +1,4 @@
+New-Item -ItemType Directory -Force .\testOutput\license | Out-Null
 $licenseOutput = (Resolve-Path .\testOutput\license\)
 $licenseOutput = "$licenseOutput\licenseCheckResults.md"
 cmd.exe /c "runlicensecheck.bat $licenseOutput"

--- a/ci/scripts/tests/translationCheck.ps1
+++ b/ci/scripts/tests/translationCheck.ps1
@@ -1,3 +1,7 @@
+
+# Ensure testOutput directory exists for log redirection
+New-Item -ItemType Directory -Force testOutput | Out-Null
+
 if ($env:RUNNER_DEBUG) {
 	cmd.exe /c "scons checkPot -j1 2> testOutput\translationCheckResults.log"
 } else {

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -42,8 +42,9 @@
 - SCons キャッシュ/引数の整合（ci/scripts/setSconsArgs.ps1 準拠）
 - Lint（ruff）ジョブ追加・安定化
 - 7z ラウンドトリップ除去（Python化）
-- ユニット/必要最小のシステムテストを安定して通す（installerタグは除外可）
+- ユニット/必要最小のシステムテストを安定して通す（installer タグは最小構成で運用可）
 - testAndPublish の主要ジョブを windows-2025 へ（後述: ランナー移行計画）
+- 上流追従容易化: testAndPublish.yml は上流原本を優先し、JP 固有はスクリプト呼び出しの最小パッチに集約
 
 ## Phase 2 : Python 3.13 対応（Part of #530）
 
@@ -121,6 +122,20 @@
 - Gate A（Phase 2 中間）: 3.13 x64 で unit + 最小 system が安定緑 → installer/署名/シンボル確認へ
 - Gate B（Phase 2 完了）: 3.13 x64 が配布可能、3.11 x86 は EOL まで保守可能 → Phase 3 へ
 - Gate C（Phase 3 開始前）: dry-run マージ結果と衝突一覧の承認 → 実マージ・段階導入へ
+
+## 現在の作業キュー（Step 1, refs #539）
+
+- PR #548（ドラフト）: CI 安定化フォローアップ（unit / license / translator）
+  - unit tests: `nvda-misc-deps`（editable）をテスト実行環境へ組み込み（rununittests.bat の `uv --group dev --group unit-tests`）
+  - license check: `testOutput/license` 事前作成＋結果をアーティファクトへ
+  - translator comments: ログ（translationCheckResults.log）をアーティファクトへ
+  - system tests: インストーラ導入前に `beforeTests.ps1` を実行（ディレクトリ作成）
+
+## 運用ルール（ブランチ/PR）
+
+- `betajp` は安定ブランチ（直接 push 禁止）。すべてトピックブランチ→PR で変更。
+- ブランチ保護: `allTestsPass` / TypeCheck を必須チェックに設定。
+- testAndPublish.yml は「上流置換 → JP パッチ再適用」の手順で保守。
 
 ## 参照
 

--- a/rununittests.bat
+++ b/rununittests.bat
@@ -7,5 +7,6 @@ set testOutput=%here%\testOutput\unit
 md %testOutput%
 
 rem Ensure nvda-misc-deps (editable) is on sys.path by including the 'dev' group alongside 'unit-tests'
-call uv run --group dev --group unit-tests --directory "%here%" -m xmlrunner discover -b -s "%unitTestsPath%" -t "%here%" --output-file "%testOutput%\unitTests.xml" %*
+call uv run --with pylouis --group dev --group unit-tests --directory "%here%" -m xmlrunner discover -b -s "%unitTestsPath%" -t "%here%" --output-file "%testOutput%\unitTests.xml" %*
+
 

--- a/rununittests.bat
+++ b/rununittests.bat
@@ -6,8 +6,8 @@ set unitTestsPath=%here%\tests\unit
 set testOutput=%here%\testOutput\unit
 md %testOutput%
 
-rem Ensure liblouis.dll can be found during unit tests
-set PATH=%here%\source;%here%\build\x86\liblouis;%PATH%
+rem Ensure liblouis.dll and dependent DLLs can be found during unit tests
+set PATH=%here%\source;%here%\build\x86\liblouis;%here%\miscDeps\python;%PATH%
 
 rem Ensure nvda-misc-deps (editable) is on sys.path by including the 'dev' group alongside 'unit-tests'
 call uv run --with pylouis --group dev --group unit-tests --directory "%here%" -m xmlrunner discover -b -s "%unitTestsPath%" -t "%here%" --output-file "%testOutput%\unitTests.xml" %*

--- a/rununittests.bat
+++ b/rununittests.bat
@@ -6,4 +6,6 @@ set unitTestsPath=%here%\tests\unit
 set testOutput=%here%\testOutput\unit
 md %testOutput%
 
-call uv run --group unit-tests --directory "%here%" -m xmlrunner discover -b -s "%unitTestsPath%" -t "%here%" --output-file "%testOutput%\unitTests.xml" %*
+rem Ensure nvda-misc-deps (editable) is on sys.path by including the 'dev' group alongside 'unit-tests'
+call uv run --group dev --group unit-tests --directory "%here%" -m xmlrunner discover -b -s "%unitTestsPath%" -t "%here%" --output-file "%testOutput%\unitTests.xml" %*
+

--- a/rununittests.bat
+++ b/rununittests.bat
@@ -6,6 +6,9 @@ set unitTestsPath=%here%\tests\unit
 set testOutput=%here%\testOutput\unit
 md %testOutput%
 
+rem Ensure liblouis.dll can be found during unit tests
+set PATH=%here%\source;%here%\build\x86\liblouis;%PATH%
+
 rem Ensure nvda-misc-deps (editable) is on sys.path by including the 'dev' group alongside 'unit-tests'
 call uv run --with pylouis --group dev --group unit-tests --directory "%here%" -m xmlrunner discover -b -s "%unitTestsPath%" -t "%here%" --output-file "%testOutput%\unitTests.xml" %*
 


### PR DESCRIPTION
refs #539

- Fix failing unit tests (investigate and adjust tests or skip temporarily)
- Fix license check (identify offending deps and update allowlist or dependencies)
- Fix translator comments (adjust strings to pass check; align artifact naming)

This is a draft PR to continue CI stabilization for 3.11 x86 JP workflows aligned with upstream.
