### PR TITLE
Docs: Step 1 agent guidance (AGENTS.md + jp/roadmap)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,27 +3,53 @@
 このファイルは、リポジトリ内で自動化エージェント／スクリプトが守る最小限のルールと最短手順を示します。詳細な説明は人間向けドキュメントを参照してください。
 
 ## スコープ（Step 1）
+
 - 目的: 3.11 x86 を維持したまま「本家版寄りのCI/ビルド基盤」に整合
 - 除外: x64/arm64 切替、Java Access Bridge 64bit、Python 3.13 への移行
 - 関連: Issue #539（Step 1）、Issue #530（本家版 2026.1 マージ全体）
 
 ## 禁則と優先
+
 - 破壊的操作を避ける（履歴の書換は明示指示時のみ）
 - 本家版との差分は最小化し、差分は明示的な場所に集約
 - 可能な限り SCons / 純 Python を優先（.cmd / 7z / nmake 依存は削減）
 - コードサイニング/配布は CI で行わない（Secrets を使用しない）。正式リリースはローカルで実施
 
 ## 最短コマンド
+
 - 型チェック: `ci/scripts/tests/typeCheck.ps1`（Pyright）
 - Lint（推奨）: `uv run ruff format --check && uv run ruff check`
 - ビルド例: `scons source dist launcher --all-cores`
 
 ## CI とブランチ
+
 - PR の base は通常 `betajp`
+- `betajp` は日本語版の安定ブランチ。直接 push・試行錯誤は禁止。作業は必ずトピックブランチ→Pull Request（PR）で行うこと。
+- ブランチ保護（推奨）: `betajp` に対して PR レビュー必須＋ステータスチェック必須（`allTestsPass`、`NVAccess Beta Aligned TypeCheck (3.11 x86)` など）。
+- CIでの配布系ジョブ（release 等）はデフォルト無効（フラグや条件で明示的に有効化）とし、Secrets を必要とする運用は避ける。
+
+## testAndPublish の上流追従（方針）
+
+- 目的: 本家 `testAndPublish.yml` をそのまま取り込み、JP 固有は最小パッチの注入に限定する。
+- 原則:
+  - JP 固有の前処理・後処理は `ci/scripts/` のスクリプトへ寄せる（YAML にはスクリプト呼び出しの1行だけ残す）。
+  - YAML 側の JP 追加は `# BEGIN JP PATCH` / `# END JP PATCH` のマーカーで囲う。
+  - 上流更新時はファイル丸ごと置換 → JP パッチ（最小）を再適用。
+- 実務メモ:
+  - `beforeTests.ps1` で `testOutput/` 配下を作成。
+  - installer/system tests は共通スクリプト（`installNVDA.ps1` / `tests/systemTests.ps1`）。
+  - 単体テストは `rununittests.bat` で `uv --group dev --group unit-tests` を使用（`miscDeps` を sys.path に含める）。
+
+## Actions 運用
+
+- 監視: `gh run list -w .github/workflows/testAndPublish.yml -b betajp -L 3`
+- 失敗調査: `gh run view <runId> --log`、またはチェックランのアノテーションを参照。
+- 再実行: `gh run rerun <runId> --failed`
 - 型チェックのみの本家版寄せワークフロー: `.github/workflows/nvbeta-typecheck-311x86.yml`
 - 日本語版の包括的ワークフロー: `.github/workflows/testAndPublish.yml`
 
 ## 参照
+
 - 人間向けハブ: `projectDocs/jp/README.md`
 - 本家版の開発環境: `projectDocs/dev/createDevEnvironment.md`
 - 日本語版の概要: `readme-nvdajp.md`

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -42,8 +42,9 @@
 - SCons キャッシュ/引数の整合（ci/scripts/setSconsArgs.ps1 準拠）
 - Lint（ruff）ジョブ追加・安定化
 - 7z ラウンドトリップ除去（Python化）
-- ユニット/必要最小のシステムテストを安定して通す（installerタグは除外可）
+- ユニット/必要最小のシステムテストを安定して通す（installer タグは最小構成で運用可）
 - testAndPublish の主要ジョブを windows-2025 へ（後述: ランナー移行計画）
+- 上流追従容易化: testAndPublish.yml は上流原本を優先し、JP 固有はスクリプト呼び出しの最小パッチに集約
 
 ## Phase 2 : Python 3.13 対応（Part of #530）
 
@@ -121,6 +122,20 @@
 - Gate A（Phase 2 中間）: 3.13 x64 で unit + 最小 system が安定緑 → installer/署名/シンボル確認へ
 - Gate B（Phase 2 完了）: 3.13 x64 が配布可能、3.11 x86 は EOL まで保守可能 → Phase 3 へ
 - Gate C（Phase 3 開始前）: dry-run マージ結果と衝突一覧の承認 → 実マージ・段階導入へ
+
+## 現在の作業キュー（Step 1, refs #539）
+
+- PR #548（ドラフト）: CI 安定化フォローアップ（unit / license / translator）
+  - unit tests: `nvda-misc-deps`（editable）をテスト実行環境へ組み込み（rununittests.bat の `uv --group dev --group unit-tests`）
+  - license check: `testOutput/license` 事前作成＋結果をアーティファクトへ
+  - translator comments: ログ（translationCheckResults.log）をアーティファクトへ
+  - system tests: インストーラ導入前に `beforeTests.ps1` を実行（ディレクトリ作成）
+
+## 運用ルール（ブランチ/PR）
+
+- `betajp` は安定ブランチ（直接 push 禁止）。すべてトピックブランチ→PR で変更。
+- ブランチ保護: `allTestsPass` / TypeCheck を必須チェックに設定。
+- testAndPublish.yml は「上流置換 → JP パッチ再適用」の手順で保守。
 
 ## 参照
 

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -36,7 +36,7 @@
 
 ## Phase 1 : 基盤整合と安定化
 
-- Windows 32bit / Python 3.11 x86 を基盤とし、本家版との差分を最小化
+- Windows 32-bit / Python 3.11 (x86) を基盤とし、本家版（rc ブランチ、2025.3.1）との差分を最小化する
 - \.python-versions を 3.11 x86 のみに固定
 - CI を SCons で成立させ、.cmd 経由を可能な範囲で排除
 - SCons キャッシュ/引数の整合（ci/scripts/setSconsArgs.ps1 準拠）


### PR DESCRIPTION
Carry over the development agent guidelines and Step 1 roadmap updates after resetting betajp to f3ab5ac.\n\n- AGENTS.md: branch/PR policy, upstream sync policy for workflows, Actions usage\n- projectDocs/jp/roadmap.md: Step 1 tasks/status, PR-first workflow, upstream-aligned strategy\n\nThis PR only updates docs; no workflow/runtime changes.