### PR TITLE
build(jp): migrate nonCertBuild wrapper to Python

### DIFF
--- a/ci/scripts/tests/diagBrailleEnv.py
+++ b/ci/scripts/tests/diagBrailleEnv.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Optional
+from typing import Any, Optional, Mapping, cast
 
 try:
     # Importing tests.unit triggers the unit test harness initialization
@@ -9,8 +9,9 @@ try:
     import braille
 
     lang = languageHandler.getLanguage()
-    conf_any: Any = config.conf  # type: ignore[reportAttributeAccessIssue]
-    braille_conf: Any = conf_any["braille"]  # type: ignore[reportIndexIssue]
+    # Treat config.conf as a mapping for diagnostics; avoid over‑promising concrete types
+    conf_map: Mapping[str, Any] = cast(Mapping[str, Any], config.conf)  # type: ignore[reportAttributeAccessIssue]
+    braille_conf: Any = conf_map.get("braille")
     table = braille_conf.get("translationTable") if hasattr(braille_conf, "get") else None
 
     handler: Optional[Any] = getattr(braille, "handler", None)

--- a/ci/scripts/tests/diagBrailleEnv.py
+++ b/ci/scripts/tests/diagBrailleEnv.py
@@ -1,0 +1,22 @@
+import sys
+
+try:
+    # Importing tests.unit triggers the unit test harness initialization
+    import tests.unit  # noqa: F401
+    import languageHandler
+    import config
+    import braille
+
+    lang = languageHandler.getLanguage()
+    table = config.conf["braille"].get("translationTable")
+    dims = braille.handler.displayDimensions
+    disp = getattr(braille.handler, "buffer", None)
+    size = getattr(disp, "displaySize", None)
+    print(f"[diag] language={lang}")
+    print(f"[diag] translationTable={table}")
+    print(f"[diag] displayDimensions rows={dims.numRows} cols={dims.numCols}")
+    print(f"[diag] buffer.displaySize={size}")
+except Exception as e:
+    print(f"[diag] error: {e}")
+    sys.exit(0)
+

--- a/ci/scripts/tests/diagBrailleEnv.py
+++ b/ci/scripts/tests/diagBrailleEnv.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any, Optional
 
 try:
     # Importing tests.unit triggers the unit test harness initialization
@@ -8,15 +9,23 @@ try:
     import braille
 
     lang = languageHandler.getLanguage()
-    table = config.conf["braille"].get("translationTable")
-    dims = braille.handler.displayDimensions
-    disp = getattr(braille.handler, "buffer", None)
+    conf_any: Any = config.conf  # type: ignore[reportAttributeAccessIssue]
+    braille_conf: Any = conf_any["braille"]  # type: ignore[reportIndexIssue]
+    table = braille_conf.get("translationTable") if hasattr(braille_conf, "get") else None
+
+    handler: Optional[Any] = getattr(braille, "handler", None)
+    dims = getattr(handler, "displayDimensions", None)
+    disp = getattr(handler, "buffer", None)
     size = getattr(disp, "displaySize", None)
     print(f"[diag] language={lang}")
     print(f"[diag] translationTable={table}")
-    print(f"[diag] displayDimensions rows={dims.numRows} cols={dims.numCols}")
+    if dims is not None:
+        rows = getattr(dims, "numRows", None)
+        cols = getattr(dims, "numCols", None)
+        print(f"[diag] displayDimensions rows={rows} cols={cols}")
+    else:
+        print("[diag] displayDimensions=None")
     print(f"[diag] buffer.displaySize={size}")
 except Exception as e:
     print(f"[diag] error: {e}")
     sys.exit(0)
-

--- a/ci/scripts/tests/unitTests.ps1
+++ b/ci/scripts/tests/unitTests.ps1
@@ -1,5 +1,13 @@
 $outDir = (Resolve-Path .\testOutput\unit\)
 $unitTestsXml = "$outDir\unitTests.xml"
+
+# Print a brief braille environment diagnostic to aid debugging
+try {
+    uv run python ci/scripts/tests/diagBrailleEnv.py
+} catch {
+    Write-Output "[diag] skipped: $_"
+}
+
 .\rununittests.bat --output-file "$unitTestsXml" -v
 if ($LastExitCode -ne 0) {
 	Write-Output "FAIL: Unit tests. See test results for more information." >> $env:GITHUB_STEP_SUMMARY

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -5,10 +5,11 @@ import subprocess
 from pathlib import Path
 
 
-def run_cmd(cmd: list[str]) -> None:
-    print(f"[nonCertBuild] run: {' '.join(cmd)}")
+def run_cmd(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+    where = f" (cwd={cwd})" if cwd else ""
+    print(f"[nonCertBuild] run: {' '.join(cmd)}{where}")
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, cwd=str(cwd) if cwd else None, env=env)
     except subprocess.CalledProcessError as e:
         # Propagate the exit code for CI to fail fast
         sys.exit(e.returncode or 1)
@@ -72,14 +73,16 @@ def _prep_miscdepsjp() -> None:
 
     # Run miscDepsJp jtalk prep/build/test
     md_root = Path("miscDepsJp/jptools")
-    run_cmd(["cmd", "/c", str(md_root / "clean.cmd")])
-    run_cmd(["cmd", "/c", str(md_root / "copy_jtalk_core_files.cmd")])
-    run_cmd(["cmd", "/c", str(md_root / "build-and-test.cmd")])
+    run_cmd(["cmd", "/c", "clean.cmd"], cwd=md_root)
+    run_cmd(["cmd", "/c", "copy_jtalk_core_files.cmd"], cwd=md_root)
+    # Keep using the existing orchestrator for now, but ensure correct working dir
+    run_cmd(["cmd", "/c", "build-and-test.cmd"], cwd=md_root)
 
     # Setup overlay for miscDepsJp
-    setup_overlay = Path("jptools/setupMiscDepsJp.cmd")
+    setup_overlay_dir = Path("jptools")
+    setup_overlay = setup_overlay_dir / "setupMiscDepsJp.cmd"
     if setup_overlay.exists():
-        run_cmd(["cmd", "/c", str(setup_overlay)])
+        run_cmd(["cmd", "/c", "setupMiscDepsJp.cmd"], cwd=setup_overlay_dir)
 
 
 def _nowdate() -> str:

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -6,11 +6,113 @@ from pathlib import Path
 
 
 def run_cmd(cmd: list[str]) -> None:
+    print(f"[nonCertBuild] run: {' '.join(cmd)}")
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as e:
         # Propagate the exit code for CI to fail fast
         sys.exit(e.returncode or 1)
+    except FileNotFoundError as e:
+        print(f"::error::Command not found: {cmd[0]} ({e})")
+        sys.exit(127)
+
+
+def _is_ci() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def _check_vs_version() -> None:
+    """Replicates jptools/check_vs_version.cmd in Python.
+    Warn on VS 2022 v17.14.8. Fail only outside CI.
+    """
+    vswhere = r"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe"
+    if not Path(vswhere).exists():
+        # Not critical; just return.
+        return
+    try:
+        # Get product display versions for VS 2022 range [17.0,18.0)
+        out = subprocess.check_output(
+            [
+                vswhere,
+                "-format",
+                "value",
+                "-property",
+                "catalog.productDisplayVersion",
+                "-products",
+                "*",
+                "-version",
+                "[17.0,18.0)",
+            ],
+            text=True,
+            errors="ignore",
+        )
+    except Exception:
+        return
+    for line in out.splitlines():
+        ver = line.strip()
+        if ver == "17.14.8":
+            print("Warning: VS 2022 v17.14.8 detected - known to cause LNK1120 build errors")
+            if _is_ci():
+                print("GitHub Actions environment - continuing with warning")
+            else:
+                print("Please downgrade to v17.14.5 or use a different version")
+                sys.exit(1)
+
+
+def _prep_miscdepsjp() -> None:
+    """Replicates nonCertBuild1.cmd steps in Python.
+    Keeps underlying module .cmd scripts, but removes top-level .cmd dependency.
+    """
+    # Only run VS environment setup locally; CI sets up MSVC via ilammy/msvc-dev-cmd
+    if not _is_ci():
+        vcsetup = Path("miscDepsJp/include/python-jtalk/vcsetup.cmd")
+        if vcsetup.exists():
+            run_cmd(["cmd", "/c", str(vcsetup)])
+    _check_vs_version()
+
+    # Run miscDepsJp jtalk prep/build/test
+    md_root = Path("miscDepsJp/jptools")
+    run_cmd(["cmd", "/c", str(md_root / "clean.cmd")])
+    run_cmd(["cmd", "/c", str(md_root / "copy_jtalk_core_files.cmd")])
+    run_cmd(["cmd", "/c", str(md_root / "build-and-test.cmd")])
+
+    # Setup overlay for miscDepsJp
+    setup_overlay = Path("jptools/setupMiscDepsJp.cmd")
+    if setup_overlay.exists():
+        run_cmd(["cmd", "/c", str(setup_overlay)])
+
+
+def _nowdate() -> str:
+    # Generate same format as jptools/nowdate.py without importing it (to avoid side effects)
+    from datetime import datetime as _dt
+    return _dt.now().strftime("%y%m%d") + chr(_dt.now().hour + 97)
+
+
+def _build_with_scons(forwarded_args: list[str]) -> None:
+    # Derive defaults when VERSION is not set
+    env = os.environ
+    version = env.get("VERSION")
+    publisher = env.get("PUBLISHER")
+    updateVersionType = env.get("UPDATEVERSIONTYPE")
+    if not version:
+        version = f"jpdev_{_nowdate()}"
+        # Match nonCertBuild2.cmd defaults for dev builds
+        publisher = publisher or "nvdajpdev"
+        updateVersionType = updateVersionType or "nvdajpdev"
+
+    # Compose SCons options
+    options = [
+        f"publisher={publisher or 'nvdajp'}",
+        f"version={version}",
+        f"updateVersionType={updateVersionType or ''}".rstrip("="),
+        "release=1",
+    ]
+    # Forward args from caller (after -- separator)
+    scons_args = options + forwarded_args
+
+    # Build targets in the same order as nonCertBuild2.cmd
+    for target in ("source", "user_docs", "dist", "launcher"):
+        run_cmd(["scons", target] + scons_args)
 
 
 def main() -> int:
@@ -18,19 +120,16 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
     os.chdir(repo_root)
 
-    # 1) Run the existing nonCertBuild1.cmd (no args)
-    run_cmd(["cmd", "/c", "jptools\\nonCertBuild1.cmd"])
-
-    # 2) Run nonCertBuild2.cmd, forwarding only args after a "--" separator
-    # This mirrors common CLI semantics and avoids passing a literal "--" to SCons.
+    # Parse args; only forward ones after "--" to SCons
     raw_args = sys.argv[1:]
     if "--" in raw_args:
         sep = raw_args.index("--")
         forwarded_args = raw_args[sep + 1 :]
     else:
         forwarded_args = raw_args
-    cmd = ["cmd", "/c", "jptools\\nonCertBuild2.cmd"] + forwarded_args
-    run_cmd(cmd)
+
+    _prep_miscdepsjp()
+    _build_with_scons(forwarded_args)
     return 0
 
 

--- a/projectDocs/jp/testAndPublish.rc-template.yml
+++ b/projectDocs/jp/testAndPublish.rc-template.yml
@@ -1,4 +1,4 @@
-name: CI/CD (rc template JP)
+# NOTE: Documentation template for reference only.\n# This file does not run in GitHub Actions.\n# To test locally, copy into .github/workflows/ and adjust as needed.\nname: CI/CD (rc template JP)
 
 on:
   workflow_dispatch:
@@ -707,4 +707,5 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber \
             $NVDA_EXE_NAME#Installer
+
 

--- a/projectDocs/jp/testAndPublish.step1-rc.yml
+++ b/projectDocs/jp/testAndPublish.step1-rc.yml
@@ -1,4 +1,4 @@
-on:
+# NOTE: Documentation template for reference only.\n# This file does not run in GitHub Actions.\n# To test locally, copy into .github/workflows/ and adjust as needed.\non:
   workflow_dispatch:
 
 name: CI/CD
@@ -693,4 +693,5 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber \
             $NVDA_EXE_NAME#Installer
+
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -89,6 +89,11 @@ speech.initialize()
 
 import braille  # noqa: E402
 
+# Force English braille table for unit tests to match upstream expectations
+# JP branch defaults to a Japanese table via configSpec; tests assume English widths
+import config  # noqa: E402
+config.conf["braille"]["translationTable"] = "en-ueb-g1.ctb"
+
 # Disable auto detection of braille displays when unit testing.
 config.conf["braille"]["display"] = "noBraille"
 braille.initialize()


### PR DESCRIPTION
非署名ビルドラッパーを Python 化して、SCons 主体のCI/ビルドに近づけます。

主な変更点:
- nonCertBuild1/2.cmd の上位ラッパーを Python で実装（`jptools/nonCertBuild.py`）
- ユニットテストを確実にするために louis のテーブルを英語に固定

スコープ:
- 上位 .cmd 依存の削減（下層の miscDepsJp/*.cmd は現状維持）
- CI の安定化と将来のSCons統合に向けた第一歩

影響:
- `testAndPublish.yml` の既存呼び出し（`uv run python jptools/nonCertBuild.py -- %sconsArgs%`）と互換
