### PR TITLE
docs(ci): mark JP testAndPublish templates as documentation-only

### DIFF
--- a/projectDocs/jp/testAndPublish.rc-template.yml
+++ b/projectDocs/jp/testAndPublish.rc-template.yml
@@ -1,4 +1,4 @@
-name: CI/CD (rc template JP)
+# NOTE: Documentation template for reference only.\n# This file does not run in GitHub Actions.\n# To test locally, copy into .github/workflows/ and adjust as needed.\nname: CI/CD (rc template JP)
 
 on:
   workflow_dispatch:
@@ -707,4 +707,5 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber \
             $NVDA_EXE_NAME#Installer
+
 

--- a/projectDocs/jp/testAndPublish.step1-rc.yml
+++ b/projectDocs/jp/testAndPublish.step1-rc.yml
@@ -1,4 +1,4 @@
-on:
+# NOTE: Documentation template for reference only.\n# This file does not run in GitHub Actions.\n# To test locally, copy into .github/workflows/ and adjust as needed.\non:
   workflow_dispatch:
 
 name: CI/CD
@@ -693,4 +693,5 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber \
             $NVDA_EXE_NAME#Installer
+
 


### PR DESCRIPTION
`.github/workflows/` から退避した JP テンプレートを、ドキュメント用であることを明示します。

- `projectDocs/jp/testAndPublish.rc-template.yml`
- `projectDocs/jp/testAndPublish.step1-rc.yml`

先頭に注記を追加:
- Documentation template for reference only / Actions では実行しない

狙い:
- 本番ワークフロー（`.github/workflows/testAndPublish.yml`）との混同を避ける
- 上流追従時の参照用テンプレートとして維持