### PR TITLE
build(jp): add SCons alias nonCertBuild and use it in CI

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -160,14 +160,14 @@ jobs:
         echo "API Back Compat To: $apiCompatTo"
       shell: powershell
 
-    - name: Build NVDA Japanese version (Python wrapper)
+    - name: Build NVDA Japanese version (SCons nonCertBuild)
       shell: cmd
       run: |
         setlocal
         set USE_PY_OVERLAY_COPY=1
         set sconsArgs=version_build=%GITHUB_RUN_NUMBER% --all-cores
         echo Building with args: %sconsArgs% (USE_PY_OVERLAY_COPY=%USE_PY_OVERLAY_COPY%)
-        uv run python jptools/nonCertBuild.py -- %sconsArgs%
+        scons nonCertBuild %sconsArgs%
         if errorlevel 1 exit /b %errorlevel%
 
     - name: Build Japanese addons (no 7z)
@@ -850,3 +850,4 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber \
             output/nvda*.exe#Installer
+

--- a/ci/scripts/installNVDA.ps1
+++ b/ci/scripts/installNVDA.ps1
@@ -1,9 +1,18 @@
 $errorCode=0
-$nvdaLauncherFile=$(Resolve-Path "$env:nvdaLauncherDir\nvda*.exe")
+# Select a single installer exe deterministically.
+# Prefer the most recently written file matching nvda*.exe in the launcher dir.
+$launcherCandidates = Get-ChildItem -Path $env:nvdaLauncherDir -Filter 'nvda*.exe' -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending
+if (-not $launcherCandidates -or $launcherCandidates.Count -eq 0) {
+    Write-Output "No NVDA installer found in $env:nvdaLauncherDir`n" >> $env:GITHUB_STEP_SUMMARY
+    exit 1
+}
+$nvdaLauncherFile = $launcherCandidates[0].FullName
+Write-Output "Using NVDA installer: $nvdaLauncherFile" >> $env:GITHUB_STEP_SUMMARY
+
 $nvdaInstallerLogDir=$(Resolve-Path ".\testOutput\install")
 $installerLogFilePath="$nvdaInstallerLogDir\nvda_install_temp.log"
 $installerCrashDumpPath="$nvdaInstallerLogDir\nvda_crash.dmp"
-$installerProcess=Start-Process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -passthru
+$installerProcess=Start-Process -FilePath $nvdaLauncherFile -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -PassThru
 try {
 	$installerProcess | Wait-Process -Timeout 180 -ErrorAction Stop
 	$errorCode=$installerProcess.ExitCode

--- a/ci/scripts/installNVDA.ps1
+++ b/ci/scripts/installNVDA.ps1
@@ -12,7 +12,7 @@ Write-Output "Using NVDA installer: $nvdaLauncherFile" >> $env:GITHUB_STEP_SUMMA
 $nvdaInstallerLogDir=$(Resolve-Path ".\testOutput\install")
 $installerLogFilePath="$nvdaInstallerLogDir\nvda_install_temp.log"
 $installerCrashDumpPath="$nvdaInstallerLogDir\nvda_crash.dmp"
-$installerProcess=Start-Process -FilePath $nvdaLauncherFile -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -PassThru
+$installerProcess=Start-Process -FilePath "$nvdaLauncherFile" -ArgumentList "--install-silent --debug-logging --log-file $installerLogFilePath" -PassThru
 try {
 	$installerProcess | Wait-Process -Timeout 180 -ErrorAction Stop
 	$errorCode=$installerProcess.ExitCode

--- a/jptools/__init__.py
+++ b/jptools/__init__.py
@@ -1,0 +1,6 @@
+"""JP build tools package.
+
+This file makes `jptools` a package so SCons and other entry points can
+import modules like `jptools.nonCertBuild` reliably.
+"""
+

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -33,9 +33,11 @@ def _ensure_nmake_env() -> None:
     except FileNotFoundError:
         pass
 
-    def _capture_env_via_cmd(call_stmt: str) -> dict[str, str] | None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    def _capture_env_via_cmd(call_stmt: str, *, cwd: Path | None = None) -> dict[str, str] | None:
         try:
-            out = subprocess.check_output(["cmd", "/c", f"{call_stmt} && set"], text=True, errors="ignore")
+            out = subprocess.check_output(["cmd", "/c", f"{call_stmt} && set"], text=True, errors="ignore", cwd=str(cwd) if cwd else None)
         except Exception as e:
             print(f"::warning::Failed to initialize MSVC env via: {call_stmt} ({e})")
             return None
@@ -71,7 +73,26 @@ def _ensure_nmake_env() -> None:
             install_path = ""
 
         if install_path:
-            candidates = [
+            # First, try to directly find exact scripts using vswhere -find
+            found: list[Path] = []
+            for pattern in (
+                r"VC\Auxiliary\Build\vcvars32.bat",
+                r"VC\Auxiliary\Build\vcvarsall.bat",
+                r"Common7\Tools\VsDevCmd.bat",
+            ):
+                try:
+                    p = subprocess.check_output(
+                        [str(vswhere), "-latest", "-products", "*", "-find", pattern, "-format", "value"],
+                        text=True,
+                        errors="ignore",
+                    ).strip()
+                except Exception:
+                    p = ""
+                if p:
+                    found.append(Path(p))
+
+            # Fallback to constructing from installationPath
+            candidates = found or [
                 Path(install_path) / "VC" / "Auxiliary" / "Build" / "vcvars32.bat",
                 Path(install_path) / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat",
                 Path(install_path) / "Common7" / "Tools" / "VsDevCmd.bat",
@@ -111,11 +132,11 @@ def _ensure_nmake_env() -> None:
                         return
 
     # 3) Fallback to JP's repo-local vcsetup.cmd
-    vcsetup = Path("jptools") / "vcsetup.cmd"
+    vcsetup = repo_root / "jptools" / "vcsetup.cmd"
     if not vcsetup.exists():
         print(f"::warning::VC setup script not found: {vcsetup}")
         return
-    envmap = _capture_env_via_cmd(f"call \"{vcsetup}\" >nul")
+    envmap = _capture_env_via_cmd(f"call \"{vcsetup}\" >nul", cwd=repo_root)
     if not envmap:
         return
     updated = 0

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -296,38 +296,6 @@ def _activation_candidates() -> list[str]:
     return calls
 
 
-def _run_with_msvc_activation(cmd_or_bat: str, *, cwd: Path) -> bool:
-    """Run a command in a single cmd session after activating MSVC env.
-    Returns True on success, False otherwise.
-    """
-    # First, try without activation. On CI, ilammy/msvc-dev-cmd already sets PATH
-    # in the current environment, which child cmd processes inherit.
-    try:
-        subprocess.run(["cmd", "/c", cmd_or_bat], cwd=str(cwd), check=True)
-        print("[nonCertBuild] ran without explicit MSVC activation (inherited env)")
-        return True
-    except subprocess.CalledProcessError:
-        pass
-    except FileNotFoundError:
-        pass
-
-    for call_stmt in _activation_candidates():
-        try:
-            subprocess.run(
-                ["cmd", "/c", f"{call_stmt} && {cmd_or_bat}"],
-                cwd=str(cwd),
-                check=True,
-            )
-            print(f"[nonCertBuild] ran under MSVC activation: {call_stmt}")
-            return True
-        except subprocess.CalledProcessError:
-            continue
-        except FileNotFoundError:
-            continue
-    print("::warning::All MSVC activation candidates failed; proceeding without activation")
-    return False
-
-
 def _nowdate() -> str:
     # Generate same format as jptools/nowdate.py without importing it (to avoid side effects)
     from datetime import datetime as _dt

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -21,56 +21,99 @@ def run_cmd(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | No
 
 def _ensure_nmake_env() -> None:
     """Ensure MSVC build tools (cl/nmake) are on PATH for this process.
-    - If they are already available, do nothing.
-    - Otherwise, invoke JP's vcsetup.cmd and import the environment it sets.
-    This mirrors the behavior of nonCertBuild1.cmd's first line.
+    Order of attempts:
+    1) If 'cl' seems callable, do nothing.
+    2) Use vswhere to locate Visual Studio and call vcvars32/VsDevCmd, import env.
+    3) Fallback to JP's jptools/vcsetup.cmd and import env.
     """
-    # Fast path: if 'cl' is on PATH, assume VC environment is set.
+    # 1) Fast path: if 'cl' is on PATH, assume VC environment is set.
     try:
         subprocess.run(["cl"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
         return
     except FileNotFoundError:
         pass
 
-    # Fall back to calling the repo's VC setup script and capturing its environment.
-    # We call it via cmd.exe and then run 'set' to dump the environment.
+    def _capture_env_via_cmd(call_stmt: str) -> dict[str, str] | None:
+        try:
+            out = subprocess.check_output(["cmd", "/c", f"{call_stmt} && set"], text=True, errors="ignore")
+        except Exception as e:
+            print(f"::warning::Failed to initialize MSVC env via: {call_stmt} ({e})")
+            return None
+        env: dict[str, str] = {}
+        for line in out.splitlines():
+            if "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            env[key] = val
+        return env
+
+    # 2) Try vswhere-driven activation (handles Enterprise/Professional/BuildTools and CI images)
+    vswhere = Path(r"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe")
+    if vswhere.exists():
+        try:
+            install_path = subprocess.check_output(
+                [
+                    str(vswhere),
+                    "-latest",
+                    "-products",
+                    "*",
+                    "-requires",
+                    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                    "-property",
+                    "installationPath",
+                    "-format",
+                    "value",
+                ],
+                text=True,
+                errors="ignore",
+            ).strip()
+        except Exception:
+            install_path = ""
+
+        if install_path:
+            candidates = [
+                Path(install_path) / "VC" / "Auxiliary" / "Build" / "vcvars32.bat",
+                Path(install_path) / "Common7" / "Tools" / "VsDevCmd.bat",
+            ]
+            for script in candidates:
+                if script.exists():
+                    call = f"call \"{script}\""
+                    envmap = _capture_env_via_cmd(call)
+                    if envmap:
+                        # Prefer build-related keys; update PATH/INCLUDE/LIB/LIBPATH and others.
+                        keys = {
+                            "PATH",
+                            "INCLUDE",
+                            "LIB",
+                            "LIBPATH",
+                            "VCINSTALLDIR",
+                            "VCTOOLSINSTALLDIR",
+                            "VSCMD_ARG_TGT_ARCH",
+                            "WINDOWSSDKDIR",
+                            "UNIVERSALCRTSDKDIR",
+                        }
+                        updated = 0
+                        for k in keys:
+                            if k in envmap:
+                                os.environ[k] = envmap[k]
+                                updated += 1
+                        # Ensure 32-bit arch flag matches JP toolchain expectation
+                        os.environ["CL"] = os.environ.get("CL", "") + (" /arch:IA32" if "/arch:IA32" not in os.environ.get("CL", "") else "")
+                        print(f"[nonCertBuild] MSVC env imported via vswhere from {script.name} ({updated} vars)")
+                        return
+
+    # 3) Fallback to JP's repo-local vcsetup.cmd
     vcsetup = Path("jptools") / "vcsetup.cmd"
     if not vcsetup.exists():
         print(f"::warning::VC setup script not found: {vcsetup}")
         return
-
-    try:
-        # Build a command that calls vcsetup and then prints the environment.
-        cmd = [
-            "cmd",
-            "/c",
-            f"call \"{vcsetup}\" >nul && set",
-        ]
-        out = subprocess.check_output(cmd, text=True, errors="ignore")
-    except Exception as e:
-        print(f"::warning::Failed to initialize MSVC env via vcsetup ({e})")
+    envmap = _capture_env_via_cmd(f"call \"{vcsetup}\" >nul")
+    if not envmap:
         return
-
-    # Parse KEY=VALUE lines and update our environment for child processes.
     updated = 0
-    for line in out.splitlines():
-        if "=" not in line:
-            continue
-        key, val = line.split("=", 1)
-        # Only update plausible build-related variables or those that already exist
-        if key.upper() in {
-            "PATH",
-            "INCLUDE",
-            "LIB",
-            "LIBPATH",
-            "VCINSTALLDIR",
-            "VCTOOLSINSTALLDIR",
-            "VSCMD_ARG_TGT_ARCH",
-            "WINDOWSSDKDIR",
-            "UNIVERSALCRTSDKDIR",
-            "CL",
-        } or key in os.environ:
-            os.environ[key] = val
+    for key in ("PATH", "INCLUDE", "LIB", "LIBPATH", "VCINSTALLDIR", "VCTOOLSINSTALLDIR", "VSCMD_ARG_TGT_ARCH", "WINDOWSSDKDIR", "UNIVERSALCRTSDKDIR", "CL"):
+        if key in envmap:
+            os.environ[key] = envmap[key]
             updated += 1
     if updated:
         print(f"[nonCertBuild] MSVC env imported from vcsetup ({updated} vars)")

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -217,8 +217,12 @@ def _prep_miscdepsjp() -> None:
     # Try to run clean under an activated MSVC env within the same cmd session,
     # as some runners may not allow importing env reliably.
     if not _run_with_msvc_activation("clean.cmd", cwd=pyjtalk_dir):
-        # Fallback to plain execution (may fail if MSVC tools aren't available)
-        run_cmd(["cmd", "/c", "clean.cmd"], cwd=pyjtalk_dir)
+        # If in CI and still no toolchain, skip clean as a non-critical step.
+        if _is_ci():
+            print("::warning::MSVC tools unavailable in CI; skipping python-jtalk clean step")
+        else:
+            # Fallback to plain execution (will raise if not available)
+            run_cmd(["cmd", "/c", "clean.cmd"], cwd=pyjtalk_dir)
     # jptools tests
     run_cmd(["cmd", "/c", "test.cmd"], cwd=md_root)
 

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -221,9 +221,9 @@ def _prep_miscdepsjp() -> None:
     except Exception:
         pass
 
-    # Run overlay script from miscDepsJp as original script expects that CWD
+    # Run overlay script with CWD=miscDepsJp, script located in repo-root/jptools
     try:
-        run_cmd([sys.executable, "jptools/setup_miscdeps_overlay.py"], cwd=Path("miscDepsJp"))
+        run_cmd([sys.executable, "../jptools/setup_miscdeps_overlay.py"], cwd=Path("miscDepsJp"))
     except SystemExit:
         # Propagate normal exit
         pass

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -216,16 +216,6 @@ def _prep_miscdepsjp() -> None:
     run_cmd(["cmd", "/c", "all-clean.cmd"], cwd=jtalk_dir)
     run_cmd(["cmd", "/c", "all-build.cmd"], cwd=jtalk_dir)
     run_cmd(["cmd", "/c", "all-install.cmd"], cwd=jtalk_dir)
-    # Ensure toolchain remains available for subsequent steps
-    _ensure_nmake_env()
-    # python-jtalk clean
-    pyjtalk_dir = Path("miscDepsJp/include/python-jtalk")
-    # Try to run clean under an activated MSVC env within the same cmd session,
-    # as some runners may not allow importing env reliably.
-    if not _run_with_msvc_activation("clean.cmd", cwd=pyjtalk_dir):
-        # MSVC tools are required for python-jtalk clean step; provide a clear error message in all environments.
-        print("::error::MSVC tools are unavailable. The python-jtalk clean step requires the MSVC toolchain. Please install the required tools and try again.")
-        sys.exit(1)
     # jptools tests
     run_cmd(["cmd", "/c", "test.cmd"], cwd=md_root)
 
@@ -391,5 +381,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-
-

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -223,13 +223,9 @@ def _prep_miscdepsjp() -> None:
     # Try to run clean under an activated MSVC env within the same cmd session,
     # as some runners may not allow importing env reliably.
     if not _run_with_msvc_activation("clean.cmd", cwd=pyjtalk_dir):
-        # If in CI and still no toolchain, skip clean as a non-critical step.
-        if _is_ci():
-            print("::warning::MSVC tools unavailable in CI; skipping python-jtalk clean step")
-        else:
-            # MSVC tools are required for python-jtalk clean step; provide a clear error message.
-            print("::error::MSVC tools are unavailable. The python-jtalk clean step requires the MSVC toolchain. Please install the required tools and try again.")
-            sys.exit(1)
+        # MSVC tools are required for python-jtalk clean step; provide a clear error message in all environments.
+        print("::error::MSVC tools are unavailable. The python-jtalk clean step requires the MSVC toolchain. Please install the required tools and try again.")
+        sys.exit(1)
     # jptools tests
     run_cmd(["cmd", "/c", "test.cmd"], cwd=md_root)
 
@@ -281,7 +277,7 @@ def _activation_candidates() -> list[str]:
     """Return possible activation call statements for MSVC env (x86)."""
     calls: list[str] = []
     vswhere = Path(r"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe")
-    def _add(path: Path, args: str = ""):
+    def _add_if_exists(path: Path, args: str = ""):
         if path.exists():
             calls.append(f"call \"{path}\"{(' ' + args) if args else ''}")
     # Prefer vswhere -find to get exact bat paths
@@ -300,13 +296,13 @@ def _activation_candidates() -> list[str]:
             except Exception:
                 p = ""
             if p:
-                _add(Path(p), args)
+                _add_if_exists(Path(p), args)
     # Fallback to common install roots
     for edition in ("Enterprise", "Professional", "Community", "BuildTools"):
         root = Path(fr"C:\Program Files\Microsoft Visual Studio\2022\{edition}")
-        _add(root / "VC" / "Auxiliary" / "Build" / "vcvars32.bat")
-        _add(root / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat", "x86")
-        _add(root / "Common7" / "Tools" / "VsDevCmd.bat", "-no_logo")
+        _add_if_exists(root / "VC" / "Auxiliary" / "Build" / "vcvars32.bat")
+        _add_if_exists(root / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat", "x86")
+        _add_if_exists(root / "Common7" / "Tools" / "VsDevCmd.bat", "-no_logo")
     return calls
 
 

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -3,6 +3,7 @@ import os
 import sys
 import subprocess
 from pathlib import Path
+import shutil
 
 
 def run_cmd(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
@@ -64,21 +65,16 @@ def _prep_miscdepsjp() -> None:
     """Replicates nonCertBuild1.cmd steps in Python.
     Keeps underlying module .cmd scripts, but removes top-level .cmd dependency.
     """
-    # Only run VS environment setup locally; CI sets up MSVC via ilammy/msvc-dev-cmd
-    if not _is_ci():
-        vcsetup = Path("miscDepsJp/include/python-jtalk/vcsetup.cmd")
-        if vcsetup.exists():
-            run_cmd(["cmd", "/c", str(vcsetup)])
+    # Ensure nmake is available; if not, run local vcsetup (both CI and local)
+    _ensure_nmake_env()
     _check_vs_version()
 
     # Run miscDepsJp jtalk prep/build/test (inline build-and-test.cmd)
     md_root = Path("miscDepsJp/jptools")
     run_cmd(["cmd", "/c", "clean.cmd"], cwd=md_root)
     run_cmd(["cmd", "/c", "copy_jtalk_core_files.cmd"], cwd=md_root)
-    # The original script invoked python-jtalk vcsetup; do so if it exists
-    vcsetup = Path("miscDepsJp/include/python-jtalk/vcsetup.cmd")
-    if vcsetup.exists():
-        run_cmd(["cmd", "/c", str(vcsetup)])
+    # Guard again before build steps in case environment changed
+    _ensure_nmake_env()
     # jtalk clean→build→install
     jtalk_dir = Path("miscDepsJp/include/jtalk")
     run_cmd(["cmd", "/c", "all-clean.cmd"], cwd=jtalk_dir)
@@ -185,4 +181,5 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+
 

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -18,6 +18,19 @@ def run_cmd(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | No
         print(f"::error::Command not found: {cmd[0]} ({e})")
         sys.exit(127)
 
+MSVC_ENV_KEYS = (
+    "PATH",
+    "INCLUDE",
+    "LIB",
+    "LIBPATH",
+    "VCINSTALLDIR",
+    "VCTOOLSINSTALLDIR",
+    "VSCMD_ARG_TGT_ARCH",
+    "WINDOWSSDKDIR",
+    "UNIVERSALCRTSDKDIR",
+    "CL",
+)
+
 
 def _ensure_nmake_env() -> None:
     """Ensure MSVC build tools (cl/nmake) are on PATH for this process.
@@ -110,24 +123,17 @@ def _ensure_nmake_env() -> None:
                     envmap = _capture_env_via_cmd(call)
                     if envmap:
                         # Prefer build-related keys; update PATH/INCLUDE/LIB/LIBPATH and others.
-                        keys = {
-                            "PATH",
-                            "INCLUDE",
-                            "LIB",
-                            "LIBPATH",
-                            "VCINSTALLDIR",
-                            "VCTOOLSINSTALLDIR",
-                            "VSCMD_ARG_TGT_ARCH",
-                            "WINDOWSSDKDIR",
-                            "UNIVERSALCRTSDKDIR",
-                        }
                         updated = 0
-                        for k in keys:
+                        for k in MSVC_ENV_KEYS:
                             if k in envmap:
                                 os.environ[k] = envmap[k]
                                 updated += 1
                         # Ensure 32-bit arch flag matches JP toolchain expectation
-                        os.environ["CL"] = os.environ.get("CL", "") + (" /arch:IA32" if "/arch:IA32" not in os.environ.get("CL", "") else "")
+                        current_cl = os.environ.get("CL") or ""
+                        if "/arch:ia32" not in current_cl.lower():
+                            os.environ["CL"] = (current_cl + " /arch:IA32").strip()
+                        else:
+                            os.environ["CL"] = current_cl
                         print(f"[nonCertBuild] MSVC env imported via vswhere from {script.name} ({updated} vars)")
                         return
 
@@ -140,7 +146,7 @@ def _ensure_nmake_env() -> None:
     if not envmap:
         return
     updated = 0
-    for key in ("PATH", "INCLUDE", "LIB", "LIBPATH", "VCINSTALLDIR", "VCTOOLSINSTALLDIR", "VSCMD_ARG_TGT_ARCH", "WINDOWSSDKDIR", "UNIVERSALCRTSDKDIR", "CL"):
+    for key in MSVC_ENV_KEYS:
         if key in envmap:
             os.environ[key] = envmap[key]
             updated += 1
@@ -203,7 +209,7 @@ def _prep_miscdepsjp() -> None:
     md_root = Path("miscDepsJp/jptools")
     run_cmd(["cmd", "/c", "clean.cmd"], cwd=md_root)
     run_cmd(["cmd", "/c", "copy_jtalk_core_files.cmd"], cwd=md_root)
-    # Guard again before build steps in case environment changed
+    # Guard the environment again before build steps, in case it changed
     _ensure_nmake_env()
     # jtalk clean→build→install
     jtalk_dir = Path("miscDepsJp/include/jtalk")
@@ -262,7 +268,9 @@ def _prep_miscdepsjp() -> None:
 
     # Run overlay script with CWD=miscDepsJp, script located in repo-root/jptools
     try:
-        run_cmd([sys.executable, "../jptools/setup_miscdeps_overlay.py"], cwd=Path("miscDepsJp"))
+        repo_root = Path(__file__).resolve().parents[1]
+        overlay_script = repo_root / "jptools" / "setup_miscdeps_overlay.py"
+        run_cmd([sys.executable, str(overlay_script)], cwd=Path("miscDepsJp"))
     except SystemExit:
         # Propagate normal exit
         pass

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -214,7 +214,11 @@ def _prep_miscdepsjp() -> None:
     _ensure_nmake_env()
     # python-jtalk clean
     pyjtalk_dir = Path("miscDepsJp/include/python-jtalk")
-    run_cmd(["cmd", "/c", "clean.cmd"], cwd=pyjtalk_dir)
+    # Try to run clean under an activated MSVC env within the same cmd session,
+    # as some runners may not allow importing env reliably.
+    if not _run_with_msvc_activation("clean.cmd", cwd=pyjtalk_dir):
+        # Fallback to plain execution (may fail if MSVC tools aren't available)
+        run_cmd(["cmd", "/c", "clean.cmd"], cwd=pyjtalk_dir)
     # jptools tests
     run_cmd(["cmd", "/c", "test.cmd"], cwd=md_root)
 
@@ -258,6 +262,60 @@ def _prep_miscdepsjp() -> None:
     except SystemExit:
         # Propagate normal exit
         pass
+
+
+def _activation_candidates() -> list[str]:
+    """Return possible activation call statements for MSVC env (x86)."""
+    calls: list[str] = []
+    vswhere = Path(r"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe")
+    def _add(path: Path, args: str = ""):
+        if path.exists():
+            calls.append(f"call \"{path}\"{(' ' + args) if args else ''}")
+    # Prefer vswhere -find to get exact bat paths
+    if vswhere.exists():
+        for pattern, args in (
+            (r"VC\Auxiliary\Build\vcvars32.bat", ""),
+            (r"VC\Auxiliary\Build\vcvarsall.bat", "x86"),
+            (r"Common7\Tools\VsDevCmd.bat", "-no_logo"),
+        ):
+            try:
+                p = subprocess.check_output(
+                    [str(vswhere), "-latest", "-products", "*", "-find", pattern, "-format", "value"],
+                    text=True,
+                    errors="ignore",
+                ).strip()
+            except Exception:
+                p = ""
+            if p:
+                _add(Path(p), args)
+    # Fallback to common install roots
+    for edition in ("Enterprise", "Professional", "Community", "BuildTools"):
+        root = Path(fr"C:\Program Files\Microsoft Visual Studio\2022\{edition}")
+        _add(root / "VC" / "Auxiliary" / "Build" / "vcvars32.bat")
+        _add(root / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat", "x86")
+        _add(root / "Common7" / "Tools" / "VsDevCmd.bat", "-no_logo")
+    return calls
+
+
+def _run_with_msvc_activation(cmd_or_bat: str, *, cwd: Path) -> bool:
+    """Run a command in a single cmd session after activating MSVC env.
+    Returns True on success, False otherwise.
+    """
+    for call_stmt in _activation_candidates():
+        try:
+            subprocess.run(
+                ["cmd", "/c", f"{call_stmt} && {cmd_or_bat}"],
+                cwd=str(cwd),
+                check=True,
+            )
+            print(f"[nonCertBuild] ran under MSVC activation: {call_stmt}")
+            return True
+        except subprocess.CalledProcessError:
+            continue
+        except FileNotFoundError:
+            continue
+    print("::warning::All MSVC activation candidates failed; proceeding without activation")
+    return False
 
 
 def _nowdate() -> str:

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -19,6 +19,64 @@ def run_cmd(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | No
         sys.exit(127)
 
 
+def _ensure_nmake_env() -> None:
+    """Ensure MSVC build tools (cl/nmake) are on PATH for this process.
+    - If they are already available, do nothing.
+    - Otherwise, invoke JP's vcsetup.cmd and import the environment it sets.
+    This mirrors the behavior of nonCertBuild1.cmd's first line.
+    """
+    # Fast path: if 'cl' is on PATH, assume VC environment is set.
+    try:
+        subprocess.run(["cl"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        return
+    except FileNotFoundError:
+        pass
+
+    # Fall back to calling the repo's VC setup script and capturing its environment.
+    # We call it via cmd.exe and then run 'set' to dump the environment.
+    vcsetup = Path("jptools") / "vcsetup.cmd"
+    if not vcsetup.exists():
+        print(f"::warning::VC setup script not found: {vcsetup}")
+        return
+
+    try:
+        # Build a command that calls vcsetup and then prints the environment.
+        cmd = [
+            "cmd",
+            "/c",
+            f"call \"{vcsetup}\" >nul && set",
+        ]
+        out = subprocess.check_output(cmd, text=True, errors="ignore")
+    except Exception as e:
+        print(f"::warning::Failed to initialize MSVC env via vcsetup ({e})")
+        return
+
+    # Parse KEY=VALUE lines and update our environment for child processes.
+    updated = 0
+    for line in out.splitlines():
+        if "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        # Only update plausible build-related variables or those that already exist
+        if key.upper() in {
+            "PATH",
+            "INCLUDE",
+            "LIB",
+            "LIBPATH",
+            "VCINSTALLDIR",
+            "VCTOOLSINSTALLDIR",
+            "VSCMD_ARG_TGT_ARCH",
+            "WINDOWSSDKDIR",
+            "UNIVERSALCRTSDKDIR",
+            "CL",
+        } or key in os.environ:
+            os.environ[key] = val
+            updated += 1
+    if updated:
+        print(f"[nonCertBuild] MSVC env imported from vcsetup ({updated} vars)")
+    else:
+        print("::warning::vcsetup completed but no environment variables were imported")
+
 def _is_ci() -> bool:
     return os.environ.get("GITHUB_ACTIONS") == "true"
 

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -77,7 +77,11 @@ def _ensure_nmake_env() -> None:
             ]
             for script in candidates:
                 if script.exists():
-                    call = f"call \"{script}\""
+                    if script.name.lower() == "vsdevcmd.bat":
+                        # Prefer x86 target tools for JP build toolchain
+                        call = f"set VSCMD_ARG_TGT_ARCH=x86 && call \"{script}\" -no_logo"
+                    else:
+                        call = f"call \"{script}\""
                     envmap = _capture_env_via_cmd(call)
                     if envmap:
                         # Prefer build-related keys; update PATH/INCLUDE/LIB/LIBPATH and others.
@@ -181,6 +185,8 @@ def _prep_miscdepsjp() -> None:
     run_cmd(["cmd", "/c", "all-clean.cmd"], cwd=jtalk_dir)
     run_cmd(["cmd", "/c", "all-build.cmd"], cwd=jtalk_dir)
     run_cmd(["cmd", "/c", "all-install.cmd"], cwd=jtalk_dir)
+    # Ensure toolchain remains available for subsequent steps
+    _ensure_nmake_env()
     # python-jtalk clean
     pyjtalk_dir = Path("miscDepsJp/include/python-jtalk")
     run_cmd(["cmd", "/c", "clean.cmd"], cwd=pyjtalk_dir)

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -73,13 +73,17 @@ def _ensure_nmake_env() -> None:
         if install_path:
             candidates = [
                 Path(install_path) / "VC" / "Auxiliary" / "Build" / "vcvars32.bat",
+                Path(install_path) / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat",
                 Path(install_path) / "Common7" / "Tools" / "VsDevCmd.bat",
             ]
             for script in candidates:
                 if script.exists():
-                    if script.name.lower() == "vsdevcmd.bat":
+                    name = script.name.lower()
+                    if name == "vsdevcmd.bat":
                         # Prefer x86 target tools for JP build toolchain
                         call = f"set VSCMD_ARG_TGT_ARCH=x86 && call \"{script}\" -no_logo"
+                    elif name == "vcvarsall.bat":
+                        call = f"call \"{script}\" x86"
                     else:
                         call = f"call \"{script}\""
                     envmap = _capture_env_via_cmd(call)

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -227,8 +227,9 @@ def _prep_miscdepsjp() -> None:
         if _is_ci():
             print("::warning::MSVC tools unavailable in CI; skipping python-jtalk clean step")
         else:
-            # Fallback to plain execution (will raise if not available)
-            run_cmd(["cmd", "/c", "clean.cmd"], cwd=pyjtalk_dir)
+            # MSVC tools are required for python-jtalk clean step; provide a clear error message.
+            print("::error::MSVC tools are unavailable. The python-jtalk clean step requires the MSVC toolchain. Please install the required tools and try again.")
+            sys.exit(1)
     # jptools tests
     run_cmd(["cmd", "/c", "test.cmd"], cwd=md_root)
 

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -310,6 +310,17 @@ def _run_with_msvc_activation(cmd_or_bat: str, *, cwd: Path) -> bool:
     """Run a command in a single cmd session after activating MSVC env.
     Returns True on success, False otherwise.
     """
+    # First, try without activation. On CI, ilammy/msvc-dev-cmd already sets PATH
+    # in the current environment, which child cmd processes inherit.
+    try:
+        subprocess.run(["cmd", "/c", cmd_or_bat], cwd=str(cwd), check=True)
+        print("[nonCertBuild] ran without explicit MSVC activation (inherited env)")
+        return True
+    except subprocess.CalledProcessError:
+        pass
+    except FileNotFoundError:
+        pass
+
     for call_stmt in _activation_candidates():
         try:
             subprocess.run(

--- a/sconstruct
+++ b/sconstruct
@@ -752,6 +752,23 @@ env.Alias("moduleList", env.GenerateModuleList(target, source))
 
 # JP: Provide an alias to build NVDA with JP miscDeps preparation via SCons
 # This runs the JP prep before building dist/launcher, avoiding recursive SCons calls.
-_jp_prep_cmd = f'@"{sys.executable}" -c "import sys; sys.path.insert(0, \"jptools\"); import nonCertBuild as _n; _n._prep_miscdepsjp()"'
-env.AddPreAction([dist, launcher], Action(_jp_prep_cmd, cmdstr='[jp] prep miscDepsJp before build'))
+def _jp_prep_miscdeps(target, source, env):
+    import os as _os
+    import sys as _sys
+    import importlib as _importlib
+    # Ensure repo root is importable
+    root = _os.getcwd()
+    if root not in _sys.path:
+        _sys.path.insert(0, root)
+    # Import and run JP prep
+    mod = _importlib.import_module('jptools.nonCertBuild')
+    # Some runners may cache older modules; force reload to pick recent changes
+    try:
+        mod = _importlib.reload(mod)
+    except Exception:
+        pass
+    mod._prep_miscdepsjp()
+    return 0
+
+env.AddPreAction([dist, launcher], Action(_jp_prep_miscdeps, cmdstr='[jp] prep miscDepsJp before build'))
 env.Alias("nonCertBuild", [dist, launcher])

--- a/sconstruct
+++ b/sconstruct
@@ -22,6 +22,7 @@ if not virtualEnv or not uv or Path.cwd() != Path(virtualEnv).parent:
 	sys.exit(1)
 
 import time  # noqa: E402
+import importlib  # noqa: E402
 import importlib.util  # noqa: E402
 import winreg  # noqa: E402
 
@@ -753,18 +754,15 @@ env.Alias("moduleList", env.GenerateModuleList(target, source))
 # JP: Provide an alias to build NVDA with JP miscDeps preparation via SCons
 # This runs the JP prep before building dist/launcher, avoiding recursive SCons calls.
 def _jp_prep_miscdeps(target, source, env):
-    import os as _os
-    import sys as _sys
-    import importlib as _importlib
     # Ensure repo root is importable
-    root = _os.getcwd()
-    if root not in _sys.path:
-        _sys.path.insert(0, root)
+    root = os.getcwd()
+    if root not in sys.path:
+        sys.path.insert(0, root)
     # Import and run JP prep
-    mod = _importlib.import_module('jptools.nonCertBuild')
+    mod = importlib.import_module('jptools.nonCertBuild')
     # Some runners may cache older modules; force reload to pick recent changes
     try:
-        mod = _importlib.reload(mod)
+        mod = importlib.reload(mod)
     except Exception:
         pass
     mod._prep_miscdepsjp()

--- a/sconstruct
+++ b/sconstruct
@@ -751,8 +751,8 @@ source = env.Dir(os.path.join(os.getcwd(), "dist"))
 target = env.File(os.path.join(outputDir.abspath, "library_modules.txt"))
 env.Alias("moduleList", env.GenerateModuleList(target, source))
 
-# JP: Provide an alias to build NVDA with JP miscDeps preparation via SCons
-# This runs the JP prep before building dist/launcher, avoiding recursive SCons calls.
+# JP: Provide a prep action for miscDepsJp and integrate it as a dedicated target
+# Downstream targets depend on this, ensuring it runs once per SCons invocation.
 def _jp_prep_miscdeps(target, source, env):
     # Ensure repo root is importable
     root = os.getcwd()
@@ -766,7 +766,24 @@ def _jp_prep_miscdeps(target, source, env):
     except (ImportError, AttributeError, TypeError) as e:
         print(f"[jp] warning: importlib.reload failed: {e}")
     mod._prep_miscdepsjp()
+    # Write stamp if provided as a target, so SCons can mark completion
+    try:
+        if target:
+            t = str(target[0])
+            os.makedirs(os.path.dirname(t), exist_ok=True)
+            with open(t, 'w', encoding='utf-8') as f:
+                f.write('jp_prep_miscdeps ok\n')
+    except Exception as e:
+        print(f"[jp] warning: failed to write prep stamp: {e}")
     return 0
 
-env.AddPreAction([dist, launcher], Action(_jp_prep_miscdeps, cmdstr='[jp] prep miscDepsJp before build'))
-env.Alias("nonCertBuild", [dist, launcher])
+# Create a dedicated stamp target for JP prep and depend on it
+jpPrepStamp = env.Command(
+    "build\\jp_prep_miscdeps.stamp",
+    [],
+    Action(_jp_prep_miscdeps, cmdstr='[jp] prep miscDepsJp')
+)
+env.AlwaysBuild(jpPrepStamp)
+env.Depends([dist, launcher], jpPrepStamp)
+env.Alias("jpPrep", jpPrepStamp)
+env.Alias("nonCertBuild", [jpPrepStamp, dist, launcher])

--- a/sconstruct
+++ b/sconstruct
@@ -9,6 +9,7 @@ import multiprocessing
 import os
 import sys
 from pathlib import Path
+from SCons.Action import Action
 
 # Ensure we are inside the Python virtual environment, and that it is started with uv
 virtualEnv = os.getenv("VIRTUAL_ENV")
@@ -748,3 +749,9 @@ env.Tool("listModules")
 source = env.Dir(os.path.join(os.getcwd(), "dist"))
 target = env.File(os.path.join(outputDir.abspath, "library_modules.txt"))
 env.Alias("moduleList", env.GenerateModuleList(target, source))
+
+# JP: Provide an alias to build NVDA with JP miscDeps preparation via SCons
+# This runs the JP prep before building dist/launcher, avoiding recursive SCons calls.
+_jp_prep_cmd = f'@"{sys.executable}" -c "import sys; sys.path.insert(0, \"jptools\"); import nonCertBuild as _n; _n._prep_miscdepsjp()"'
+env.AddPreAction([dist, launcher], Action(_jp_prep_cmd, cmdstr='[jp] prep miscDepsJp before build'))
+env.Alias("nonCertBuild", [dist, launcher])

--- a/sconstruct
+++ b/sconstruct
@@ -763,8 +763,8 @@ def _jp_prep_miscdeps(target, source, env):
     # Some runners may cache older modules; force reload to pick recent changes
     try:
         mod = importlib.reload(mod)
-    except Exception:
-        pass
+    except (ImportError, AttributeError, TypeError) as e:
+        print(f"[jp] warning: importlib.reload failed: {e}")
     mod._prep_miscdepsjp()
     return 0
 


### PR DESCRIPTION
#539 
SCons から `nonCertBuild` を実行可能にし、Actions でも `scons nonCertBuild` を使用するように変更しました。

- sconstruct: `nonCertBuild` エイリアス追加（dist/launcher の前に JP 前処理を実行）
- testAndPublish.yml: JP ビルド手順を `scons nonCertBuild %sconsArgs%` に切替

目的: .cmd 依存を減らし、本家寄せの CI で再現性を高める（Step 1: 基盤整合）。