### PR TITLE
docs(roadmap): Step 1 refresh and prep (refs #539)

### DIFF
--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -41,45 +41,18 @@ jobs:
             if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
           }
           patch --version | Select-Object -First 1
-      - name: Fetch python-jtalk vendor if missing
-        shell: pwsh
+      - name: Prepare vendor via copy_jtalk_core_files.cmd
+        shell: cmd
+        working-directory: miscDepsJp\jptools
         run: |
-          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
-          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
-            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
-            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
-            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
-            git -C "$pj" submodule update --init --recursive --depth 1
-          }
+          call copy_jtalk_core_files.cmd
+          if errorlevel 1 exit /b %errorlevel%
       - name: Sync core trees into python-jtalk
-        shell: pwsh
+        shell: cmd
+        working-directory: miscDepsJp\jptools
         run: |
-          $root = $pwd
-          $src1 = Join-Path $root 'miscDepsJp/include/libopenjtalk'
-          $src2 = Join-Path $root 'miscDepsJp/include/htsengineapi'
-          $dst = Join-Path $root 'miscDepsJp/include/python-jtalk'
-          $dst1 = Join-Path $dst 'libopenjtalk'
-          $dst2 = Join-Path $dst 'htsengineapi'
-
-          Write-Host "[info] Syncing $src1 -> $dst1"
-          robocopy "$src1" "$dst1" /E /NFL /NDL /NJH /NJS /NP | Out-Null
-          $code1 = $LASTEXITCODE
-          Write-Host "[info] robocopy exit code: $code1"
-
-          Write-Host "[info] Syncing $src2 -> $dst2"
-          robocopy "$src2" "$dst2" /E /NFL /NDL /NJH /NJS /NP | Out-Null
-          $code2 = $LASTEXITCODE
-          Write-Host "[info] robocopy exit code: $code2"
-
-          $max = [Math]::Max($code1, $code2)
-          # robocopy exit codes: 0=no changes, 1=files copied, 2-7=warnings, 8+=errors
-          if ($max -ge 8) {
-            Write-Error "robocopy failed with code $max"
-            exit $max
-          } else {
-            Write-Host "robocopy exit code aggregate: $max (treated as success)"
-            $global:LASTEXITCODE = 0
-          }
+          call copy_jtalk_core_files.cmd
+          if errorlevel 1 exit /b %errorlevel%
       - name: Verify HTS vendor tree
         shell: pwsh
         run: |
@@ -88,16 +61,6 @@ jobs:
           Get-ChildItem $htsLib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host
           if (-not (Test-Path (Join-Path $htsLib 'Makefile.mak'))) { Write-Error 'Makefile.mak missing in vendor htsengineapi/lib'; exit 1 }
           if (-not (Test-Path (Join-Path $htsLib 'HTS_label.c'))) { Write-Error 'HTS_label.c missing in vendor htsengineapi/lib'; exit 1 }
-      - name: Build HTS engine (vendor)
-        shell: cmd
-        working-directory: miscDepsJp\include\python-jtalk\htsengineapi\lib
-        run: |
-          nmake /f Makefile.mak
-      - name: Build HTS engine (vendor)
-        shell: cmd
-        working-directory: miscDepsJp\include\python-jtalk\htsengineapi\lib
-        run: |
-          nmake /f Makefile.mak
       - name: Build libopenjtalk (nmake)
         shell: cmd
         working-directory: miscDepsJp\include\python-jtalk
@@ -172,16 +135,12 @@ jobs:
             if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
           }
           patch --version | Select-Object -First 1
-      - name: Fetch python-jtalk vendor if missing
-        shell: pwsh
+      - name: Prepare vendor via copy_jtalk_core_files.cmd
+        shell: cmd
+        working-directory: miscDepsJp\jptools
         run: |
-          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
-          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
-            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
-            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
-            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
-            git -C "$pj" submodule update --init --recursive --depth 1
-          }
+          call copy_jtalk_core_files.cmd
+          if errorlevel 1 exit /b %errorlevel%
       - name: Build x64 libopenjtalk via SCons alias
         shell: cmd
         run: |

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -94,6 +94,12 @@ jobs:
           if (-not (Test-Path $p)) { Get-ChildItem -Recurse -Directory miscDepsJp | Select-Object -First 20 | Format-List | Out-String | Write-Host; throw "Makefile not found: $p" }
           (Get-Content $p -Raw) -replace '/MACHINE:x86','/MACHINE:X64' | Set-Content $p -Encoding ASCII
 
+      - name: Pre-build HTS engine (vendor lib)
+        shell: cmd
+        working-directory: miscDepsJp\include\python-jtalk\htsengineapi\lib
+        run: |
+          nmake /f Makefile.mak
+
       - name: Build libopenjtalk (nmake)
         shell: cmd
         working-directory: miscDepsJp\include\python-jtalk

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -113,23 +113,46 @@ jobs:
           $vendorLib = Join-Path $vendorHts 'lib'
           $repoHts   = Join-Path $pwd 'miscDepsJp/include/htsengineapi'
           $repoLib   = Join-Path $repoHts 'lib'
+
+          # ベンダーツリーが無ければ、リポ内の htsengineapi を vendor 配下に作成
           if (-not (Test-Path $vendorHts) -and (Test-Path $repoHts)) {
             Write-Host "[info] Creating vendor htsengineapi from repo copy"
             robocopy "$repoHts" "$vendorHts" /E /NFL /NDL /NJH /NJS /NP | Out-Null
           }
-          if (Test-Path $vendorLib) {
-            Push-Location $vendorLib
-            try { nmake /f Makefile.mak } finally { Pop-Location }
-          } elseif (Test-Path $repoLib) {
-            Push-Location $repoLib
-            try { nmake /f Makefile.mak } finally { Pop-Location }
-            # Ensure vendor path exists then copy built outputs
+
+          function Invoke-NMake($dir, $mk) {
+            Push-Location $dir
+            try { nmake /f $mk } finally { Pop-Location }
+          }
+
+          $builtFrom = $null
+          if (Test-Path (Join-Path $vendorLib 'Makefile.mak')) {
+            Invoke-NMake $vendorLib 'Makefile.mak'
+            $builtFrom = 'vendorLib'
+          } elseif (Test-Path (Join-Path $vendorHts 'Makefile.mak')) {
+            # ルートに Makefile.mak がある場合はそこでビルド
+            Invoke-NMake $vendorHts 'Makefile.mak'
+            $builtFrom = 'vendorRoot'
+          } elseif (Test-Path (Join-Path $repoLib 'Makefile.mak')) {
+            Invoke-NMake $repoLib 'Makefile.mak'
+            $builtFrom = 'repoLib'
             New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
             Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
             Get-ChildItem $repoLib -Filter *.obj | Copy-Item -Destination $vendorLib -Force
+          } elseif (Test-Path (Join-Path $repoHts 'Makefile.mak')) {
+            Invoke-NMake $repoHts 'Makefile.mak'
+            $builtFrom = 'repoRoot'
+            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
+            if (Test-Path (Join-Path $repoLib 'hts_engine_API.lib')) {
+              Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
+            }
+            if (Test-Path $repoLib) {
+              Get-ChildItem $repoLib -Filter *.obj -ErrorAction SilentlyContinue | Copy-Item -Destination $vendorLib -Force
+            }
           } else {
-            throw "Neither vendor nor repo HTS lib path exists: $vendorLib , $repoLib"
+            throw "HTS Makefile not found in vendor or repo: $vendorHts ; $repoHts"
           }
+          Write-Host "[info] HTS built from: $builtFrom"
 
       - name: Build libopenjtalk (nmake)
         shell: cmd

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -86,6 +86,18 @@ jobs:
           $max = [Math]::Max($code1, $code2)
           if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { Write-Host "robocopy exit code aggregate: $max (treated as success)"; $global:LASTEXITCODE = 0 }
 
+      - name: Diagnose tree (python-jtalk and htsengineapi)
+        shell: pwsh
+        run: |
+          Write-Host "[diag] Listing miscDepsJp/include"
+          Get-ChildItem -Path miscDepsJp/include | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
+          Write-Host "[diag] Listing python-jtalk"
+          Get-ChildItem -Path miscDepsJp/include/python-jtalk | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
+          Write-Host "[diag] Listing python-jtalk/htsengineapi"
+          if (Test-Path miscDepsJp/include/python-jtalk/htsengineapi) { Get-ChildItem -Path miscDepsJp/include/python-jtalk/htsengineapi | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
+          Write-Host "[diag] Listing repo htsengineapi/lib"
+          if (Test-Path miscDepsJp/include/htsengineapi/lib) { Get-ChildItem -Path miscDepsJp/include/htsengineapi/lib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
+
       - name: Adjust linker machine flag for x64
         if: matrix.arch == 'x64'
         shell: pwsh
@@ -97,8 +109,14 @@ jobs:
       - name: Pre-build HTS engine (vendor or repo)
         shell: pwsh
         run: |
-          $vendorLib = Join-Path $pwd 'miscDepsJp/include/python-jtalk/htsengineapi/lib'
-          $repoLib   = Join-Path $pwd 'miscDepsJp/include/htsengineapi/lib'
+          $vendorHts = Join-Path $pwd 'miscDepsJp/include/python-jtalk/htsengineapi'
+          $vendorLib = Join-Path $vendorHts 'lib'
+          $repoHts   = Join-Path $pwd 'miscDepsJp/include/htsengineapi'
+          $repoLib   = Join-Path $repoHts 'lib'
+          if (-not (Test-Path $vendorHts) -and (Test-Path $repoHts)) {
+            Write-Host "[info] Creating vendor htsengineapi from repo copy"
+            robocopy "$repoHts" "$vendorHts" /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          }
           if (Test-Path $vendorLib) {
             Push-Location $vendorLib
             try { nmake /f Makefile.mak } finally { Pop-Location }

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -64,6 +64,11 @@ jobs:
           $code2 = $LASTEXITCODE
           $max = [Math]::Max($code1, $code2)
           if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { $global:LASTEXITCODE = 0 }
+      - name: Build HTS engine (vendor)
+        shell: cmd
+        working-directory: miscDepsJp\include\python-jtalk\htsengineapi\lib
+        run: |
+          nmake /f Makefile.mak
       - name: Build libopenjtalk (nmake)
         shell: cmd
         working-directory: miscDepsJp\include\python-jtalk

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -1,0 +1,67 @@
+name: JP miscDepsJp Artifacts (311 x86/x64)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build miscDepsJp (${{ matrix.arch }})
+    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x64]
+        python: ["3.11.9"]
+    env:
+      # Make nmake verbose when we need to debug
+      NMAKE: /nologo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python }} (${{ matrix.arch }})
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: ${{ matrix.arch }}
+
+      - name: Setup MSVC (${{ matrix.arch }})
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Show toolchain
+        shell: pwsh
+        run: |
+          cl 2>$null || echo "cl not found"
+          nmake /? | Select-Object -First 1
+          python --version
+          where patch || echo "patch not found in PATH"
+
+      - name: Build libopenjtalk (nmake)
+        shell: cmd
+        working-directory: miscDepsJp\include\python-jtalk
+        run: |
+          nmake /f all.mak
+
+      - name: Collect artifacts
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path _artifacts | Out-Null
+          $dll = "miscDepsJp/include/python-jtalk/libopenjtalk.dll"
+          if (Test-Path $dll) { Copy-Item $dll _artifacts/libopenjtalk-${{ matrix.arch }}.dll }
+          Get-ChildItem -Recurse -File miscDepsJp/include/python-jtalk | Out-File _artifacts/filelist-${{ matrix.arch }}.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: miscDepsJp-${{ matrix.arch }}-artifacts
+          path: _artifacts/**
+

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -20,43 +20,27 @@ concurrency:
 jobs:
   miscdepsjp-x86:
     name: Build miscDepsJp (x86 baseline)
-    # Run when dispatched manually, or when PR has the label 'run-miscdepsjp'.
     if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdepsjp')
     runs-on: windows-2025
     env:
       NMAKE: /nologo
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python 3.11.9 (x86)
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11.9'
           architecture: x86
-
-      - name: Setup MSVC (x86)
-        uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86
-
-      - name: Show toolchain
-        shell: pwsh
-        run: |
-          cl 2>$null || echo "cl not found"
-          nmake /? | Select-Object -First 1
-          python --version
-          where patch || echo "patch not found in PATH"
-
       - name: Ensure GNU patch available
         shell: pwsh
         run: |
           if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
-            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\\usr\\bin'
+            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\usr\bin'
             if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
           }
           patch --version | Select-Object -First 1
-
       - name: Fetch python-jtalk vendor if missing
         shell: pwsh
         run: |
@@ -65,10 +49,8 @@ jobs:
             Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
             if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
             git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
-            # Ensure submodules are populated (for safety on shallow clones)
             git -C "$pj" submodule update --init --recursive --depth 1
           }
-
       - name: Sync core trees into python-jtalk
         shell: pwsh
         run: |
@@ -81,165 +63,97 @@ jobs:
           robocopy "$src2" (Join-Path $dst 'htsengineapi') /E /NFL /NDL /NJH /NJS /NP | Out-Null
           $code2 = $LASTEXITCODE
           $max = [Math]::Max($code1, $code2)
-          if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { Write-Host "robocopy exit code aggregate: $max (treated as success)"; $global:LASTEXITCODE = 0 }
-
-      - name: Diagnose tree (python-jtalk and htsengineapi)
-        shell: pwsh
-        run: |
-          Write-Host "[diag] Listing miscDepsJp/include"
-          Get-ChildItem -Path miscDepsJp/include | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
-          Write-Host "[diag] Listing python-jtalk"
-          Get-ChildItem -Path miscDepsJp/include/python-jtalk | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
-          Write-Host "[diag] Listing python-jtalk/htsengineapi"
-          if (Test-Path miscDepsJp/include/python-jtalk/htsengineapi) { Get-ChildItem -Path miscDepsJp/include/python-jtalk/htsengineapi | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
-          Write-Host "[diag] Listing repo htsengineapi/lib"
-          if (Test-Path miscDepsJp/include/htsengineapi/lib) { Get-ChildItem -Path miscDepsJp/include/htsengineapi/lib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
-
-# removed brittle HTS pre-build (rely on all.mak)
+          if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { $global:LASTEXITCODE = 0 }
       - name: Build libopenjtalk (nmake)
-
-          Write-Host "[info] HTS built from: $builtFrom"
-          }
-            throw "HTS Makefile not found in vendor or repo: $vendorHts ; $repoHts"
-          } else {
-            }
-              Get-ChildItem $repoLib -Filter *.obj -ErrorAction SilentlyContinue | Copy-Item -Destination $vendorLib -Force
-            if (Test-Path $repoLib) {
-            }
-              Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
-            if (Test-Path (Join-Path $repoLib 'hts_engine_API.lib')) {
-            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
-            $builtFrom = 'repoRoot'
-            Invoke-NMake $repoHts 'Makefile.mak'
-          } elseif (Test-Path (Join-Path $repoHts 'Makefile.mak')) {
-            Get-ChildItem $repoLib -Filter *.obj | Copy-Item -Destination $vendorLib -Force
-            Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
-            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
-            $builtFrom = 'repoLib'
-            Invoke-NMake $repoLib 'Makefile.mak'
-          } elseif (Test-Path (Join-Path $repoLib 'Makefile.mak')) {
-            $builtFrom = 'vendorRoot'
-            Invoke-NMake $vendorHts 'Makefile.mak'
-            # ルートに Makefile.mak がある場合はそこでビルド
-          } elseif (Test-Path (Join-Path $vendorHts 'Makefile.mak')) {
-            $builtFrom = 'vendorLib'
-            Invoke-NMake $vendorLib 'Makefile.mak'
-          if (Test-Path (Join-Path $vendorLib 'Makefile.mak')) {
-          $builtFrom = $null
-
-          }
-            try { nmake /f $mk } finally { Pop-Location }
-            Push-Location $dir
-          function Invoke-NMake($dir, $mk) {
-
-          }
-            robocopy "$repoHts" "$vendorHts" /E /NFL /NDL /NJH /NJS /NP | Out-Null
-            Write-Host "[info] Creating vendor htsengineapi from repo copy"
-          if (-not (Test-Path $vendorHts) -and (Test-Path $repoHts)) {
-          # ベンダーツリーが無ければ、リポ内の htsengineapi を vendor 配下に作成
-
-          $repoLib   = Join-Path $repoHts 'lib'
-          $repoHts   = Join-Path $pwd 'miscDepsJp/include/htsengineapi'
-          $vendorLib = Join-Path $vendorHts 'lib'
-          $vendorHts = Join-Path $pwd 'miscDepsJp/include/python-jtalk/htsengineapi'
+        shell: cmd
+        working-directory: miscDepsJp\include\python-jtalk
         run: |
+          nmake /f all.mak
+      - name: Collect artifacts
         shell: pwsh
-      - name: Pre-build HTS engine (vendor or repo)
-
-          if (Test-Path miscDepsJp/include/htsengineapi/lib) { Get-ChildItem -Path miscDepsJp/include/htsengineapi/lib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
-          Write-Host "[diag] Listing repo htsengineapi/lib"
-          if (Test-Path miscDepsJp/include/python-jtalk/htsengineapi) { Get-ChildItem -Path miscDepsJp/include/python-jtalk/htsengineapi | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
-          Write-Host "[diag] Listing python-jtalk/htsengineapi"
-          Get-ChildItem -Path miscDepsJp/include/python-jtalk | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
-          Write-Host "[diag] Listing python-jtalk"
-          Get-ChildItem -Path miscDepsJp/include | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
-          Write-Host "[diag] Listing miscDepsJp/include"
         run: |
-        shell: pwsh
-      - name: Diagnose tree (python-jtalk and htsengineapi)
-
-          if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { Write-Host "robocopy exit code aggregate: $max (treated as success)"; $global:LASTEXITCODE = 0 }
-          $max = [Math]::Max($code1, $code2)
-          $code2 = $LASTEXITCODE
-          robocopy "$src2" (Join-Path $dst 'htsengineapi') /E /NFL /NDL /NJH /NJS /NP | Out-Null
-          $code1 = $LASTEXITCODE
-          robocopy "$src1" (Join-Path $dst 'libopenjtalk') /E /NFL /NDL /NJH /NJS /NP | Out-Null
-          $dst = Join-Path $root 'miscDepsJp/include/python-jtalk'
-          $src2 = Join-Path $root 'miscDepsJp/include/htsengineapi'
-          $src1 = Join-Path $root 'miscDepsJp/include/libopenjtalk'
-          $root = $pwd
-        run: |
-        shell: pwsh
-      - name: Sync core trees into python-jtalk
-
-          }
-            git -C "$pj" submodule update --init --recursive --depth 1
-            # Ensure submodules are populated (for safety on shallow clones)
-            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
-            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
-            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
-          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
-          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
-        run: |
-        shell: pwsh
-      - name: Fetch python-jtalk vendor if missing
-
-          patch --version | Select-Object -First 1
-          }
-            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
-            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\\usr\\bin'
-          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
-        run: |
-        shell: pwsh
-      - name: Ensure GNU patch available
-
-          where patch || echo "patch not found in PATH"
-          python --version
-          nmake /? | Select-Object -First 1
-          cl 2>$null || echo "cl not found"
-        run: |
-        shell: pwsh
-      - name: Show toolchain
-
-          arch: x86
+          New-Item -ItemType Directory -Force -Path _artifacts | Out-Null
+          $dll = "miscDepsJp/include/python-jtalk/libopenjtalk.dll"
+          if (Test-Path $dll) { Copy-Item $dll _artifacts/libopenjtalk-x86.dll }
+          Get-ChildItem -Recurse -File miscDepsJp/include/python-jtalk | Out-File _artifacts/filelist-x86.txt
+      - uses: actions/upload-artifact@v4
         with:
-        uses: ilammy/msvc-dev-cmd@v1
-      - name: Setup MSVC (x86)
+          name: miscDepsJp-x86-artifacts
+          path: _artifacts/**
 
-          architecture: x86
-          python-version: '3.11.9'
-        with:
-        uses: actions/setup-python@v5
-      - name: Setup Python 3.11.9 (x86)
-
-        uses: actions/checkout@v4
-      - name: Checkout
-    steps:
-      NMAKE: /nologo
-    env:
+  jp-tests:
+    name: JP unit tests (optional)
+    needs: miscdepsjp-x86
+    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-jp-tests')
     runs-on: windows-2025
-    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdepsjp')
-    # Run when dispatched manually, or when PR has the label 'run-miscdepsjp'.
-    name: Build miscDepsJp (x86 baseline)
-  miscdepsjp-x86:
-jobs:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+          architecture: x86
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+      - name: Ensure GNU patch available
+        shell: pwsh
+        run: |
+          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
+            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\usr\bin'
+            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
+          }
+          patch --version | Select-Object -First 1
+      - name: Run JP tests via SCons
+        shell: cmd
+        run: |
+          scons.bat miscdepsjp jpTests jpCharTests -j1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jp-tests-logs
+          path: |
+            miscDepsJp/jptools/__test_log.txt
+            miscDepsJp/jptools/__jpBrailleHarness.md
+            miscDepsJp/jptools/jpBrailleHarness.html
 
-  cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.ref }}
-concurrency:
-
-  contents: read
-permissions:
-
-      - '.github/workflows/miscdepsjp-artifacts.yml'
-      - 'jptools/**'
-      - 'miscDepsJp/**'
-    paths:
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
-    branches: [ betajp ]
-  pull_request:
-  workflow_dispatch:
-on:
-
-name: JP miscDepsJp Artifacts (311 x86/x64)
+  miscdepsjp-x64:
+    name: Build miscDepsJp (x64 experimental)
+    needs: miscdepsjp-x86
+    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdeps64')
+    continue-on-error: true
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+          architecture: x64
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+      - name: Ensure GNU patch available
+        shell: pwsh
+        run: |
+          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
+            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\usr\bin'
+            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
+          }
+          patch --version | Select-Object -First 1
+      - name: Fetch python-jtalk vendor if missing
+        shell: pwsh
+        run: |
+          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
+          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
+            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
+            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
+            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
+            git -C "$pj" submodule update --init --recursive --depth 1
+          }
+      - name: Build x64 libopenjtalk via SCons alias
+        shell: cmd
+        run: |
+          scons.bat miscdepsjp-x64 -j1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: miscDepsJp-x64-artifacts
+          path: |
             miscDepsJp/_build/libopenjtalk-x64.dll

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -94,11 +94,24 @@ jobs:
           if (-not (Test-Path $p)) { Get-ChildItem -Recurse -Directory miscDepsJp | Select-Object -First 20 | Format-List | Out-String | Write-Host; throw "Makefile not found: $p" }
           (Get-Content $p -Raw) -replace '/MACHINE:x86','/MACHINE:X64' | Set-Content $p -Encoding ASCII
 
-      - name: Pre-build HTS engine (vendor lib)
-        shell: cmd
-        working-directory: miscDepsJp\include\python-jtalk\htsengineapi\lib
+      - name: Pre-build HTS engine (vendor or repo)
+        shell: pwsh
         run: |
-          nmake /f Makefile.mak
+          $vendorLib = Join-Path $pwd 'miscDepsJp/include/python-jtalk/htsengineapi/lib'
+          $repoLib   = Join-Path $pwd 'miscDepsJp/include/htsengineapi/lib'
+          if (Test-Path $vendorLib) {
+            Push-Location $vendorLib
+            try { nmake /f Makefile.mak } finally { Pop-Location }
+          } elseif (Test-Path $repoLib) {
+            Push-Location $repoLib
+            try { nmake /f Makefile.mak } finally { Pop-Location }
+            # Ensure vendor path exists then copy built outputs
+            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
+            Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
+            Get-ChildItem $repoLib -Filter *.obj | Copy-Item -Destination $vendorLib -Force
+          } else {
+            throw "Neither vendor nor repo HTS lib path exists: $vendorLib , $repoLib"
+          }
 
       - name: Build libopenjtalk (nmake)
         shell: cmd

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -65,9 +65,10 @@ jobs:
       - name: Adjust linker machine flag for x64
         if: matrix.arch == 'x64'
         shell: pwsh
-        working-directory: miscDepsJp/include/python-jtalk/lib
         run: |
-          (Get-Content Makefile.mak -Raw) -replace '/MACHINE:x86','/MACHINE:X64' | Set-Content Makefile.mak -Encoding ASCII
+          $p = Join-Path $pwd 'miscDepsJp/include/python-jtalk/lib/Makefile.mak'
+          if (-not (Test-Path $p)) { Get-ChildItem -Recurse -Directory miscDepsJp | Select-Object -First 20 | Format-List | Out-String | Write-Host; throw "Makefile not found: $p" }
+          (Get-Content $p -Raw) -replace '/MACHINE:x86','/MACHINE:X64' | Set-Content $p -Encoding ASCII
 
       - name: Build libopenjtalk (nmake)
         shell: cmd

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -80,7 +80,11 @@ jobs:
           $src2 = Join-Path $root 'miscDepsJp/include/htsengineapi'
           $dst = Join-Path $root 'miscDepsJp/include/python-jtalk'
           robocopy "$src1" (Join-Path $dst 'libopenjtalk') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          $code1 = $LASTEXITCODE
           robocopy "$src2" (Join-Path $dst 'htsengineapi') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          $code2 = $LASTEXITCODE
+          $max = [Math]::Max($code1, $code2)
+          if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { Write-Host "robocopy exit code aggregate: $max (treated as success)"; $global:LASTEXITCODE = 0 }
 
       - name: Adjust linker machine flag for x64
         if: matrix.arch == 'x64'

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -2,6 +2,12 @@ name: JP miscDepsJp Artifacts (311 x86/x64)
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ betajp ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    paths:
+      - 'miscDepsJp/**'
+      - '.github/workflows/miscdepsjp-artifacts.yml'
 
 permissions:
   contents: read
@@ -13,6 +19,8 @@ concurrency:
 jobs:
   build:
     name: Build miscDepsJp (${{ matrix.arch }})
+    # Run when dispatched manually, or when PR has the label 'run-miscdepsjp'.
+    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdepsjp')
     runs-on: windows-2025
     strategy:
       fail-fast: false

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -47,12 +47,13 @@ jobs:
         run: |
           setlocal
           set XCOPYCMD=/I /Y
+          mkdir ..\include\python-jtalk 2>nul
           mkdir ..\include\jtalk 2>nul
           mkdir ..\include\python-jtalk\htsengineapi 2>nul
           mkdir ..\include\python-jtalk\libopenjtalk 2>nul
           mkdir ..\source\synthDrivers\jtalk 2>nul
           call copy_jtalk_core_files.cmd
-          if errorlevel 1 exit /b %errorlevel%
+          rem ignore non-zero exit; verify in next step
           endlocal
       - name: Verify HTS vendor tree
         shell: pwsh
@@ -142,12 +143,13 @@ jobs:
         run: |
           setlocal
           set XCOPYCMD=/I /Y
+          mkdir ..\include\python-jtalk 2>nul
           mkdir ..\include\jtalk 2>nul
           mkdir ..\include\python-jtalk\htsengineapi 2>nul
           mkdir ..\include\python-jtalk\libopenjtalk 2>nul
           mkdir ..\source\synthDrivers\jtalk 2>nul
           call copy_jtalk_core_files.cmd
-          if errorlevel 1 exit /b %errorlevel%
+          rem ignore non-zero exit; x64 is experimental and SCons will validate
           endlocal
       - name: Build x64 libopenjtalk via SCons alias
         shell: cmd

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -60,17 +60,26 @@ jobs:
           $dst = Join-Path $root 'miscDepsJp/include/python-jtalk'
           $dst1 = Join-Path $dst 'libopenjtalk'
           $dst2 = Join-Path $dst 'htsengineapi'
-          New-Item -ItemType Directory -Force -Path $dst1 | Out-Null
-          New-Item -ItemType Directory -Force -Path $dst2 | Out-Null
-          # Try robocopy first (fast), then fallback to Copy-Item for reliability
+
+          Write-Host "[info] Syncing $src1 -> $dst1"
           robocopy "$src1" "$dst1" /E /NFL /NDL /NJH /NJS /NP | Out-Null
           $code1 = $LASTEXITCODE
+          Write-Host "[info] robocopy exit code: $code1"
+
+          Write-Host "[info] Syncing $src2 -> $dst2"
           robocopy "$src2" "$dst2" /E /NFL /NDL /NJH /NJS /NP | Out-Null
           $code2 = $LASTEXITCODE
+          Write-Host "[info] robocopy exit code: $code2"
+
           $max = [Math]::Max($code1, $code2)
-          if ($code1 -ge 8) { Copy-Item -Recurse -Force "$src1\*" $dst1 }
-          if ($code2 -ge 8) { Copy-Item -Recurse -Force "$src2\*" $dst2 }
-          if ($max -ge 8) { Write-Host "[warn] robocopy had errors (code=$max), used Copy-Item fallback"; $global:LASTEXITCODE = 0 }
+          # robocopy exit codes: 0=no changes, 1=files copied, 2-7=warnings, 8+=errors
+          if ($max -ge 8) {
+            Write-Error "robocopy failed with code $max"
+            exit $max
+          } else {
+            Write-Host "robocopy exit code aggregate: $max (treated as success)"
+            $global:LASTEXITCODE = 0
+          }
       - name: Verify HTS vendor tree
         shell: pwsh
         run: |
@@ -182,3 +191,4 @@ jobs:
           name: miscDepsJp-x64-artifacts
           path: |
             miscDepsJp/_build/libopenjtalk-x64.dll
+

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -175,3 +175,38 @@ jobs:
         with:
           name: miscDepsJp-${{ matrix.arch }}-artifacts
           path: _artifacts/**
+
+  jp-tests:
+    name: JP unit tests (optional)
+    needs: build
+    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-jp-tests')
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+          architecture: x86
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+      - name: Ensure GNU patch available
+        shell: pwsh
+        run: |
+          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
+            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\usr\bin'
+            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
+          }
+          patch --version | Select-Object -First 1
+      - name: Run JP tests via SCons
+        shell: pwsh
+        run: |
+          uv run scons miscdepsjp jpTests jpCharTests -j1
+      - name: Upload JP test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: jp-tests-logs
+          path: |
+            miscDepsJp/jptools/__test_log.txt
+            miscDepsJp/jptools/__jpBrailleHarness.md
+            miscDepsJp/jptools/jpBrailleHarness.html

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -45,14 +45,15 @@ jobs:
         shell: cmd
         working-directory: miscDepsJp\jptools
         run: |
+          setlocal
+          set XCOPYCMD=/I /Y
+          mkdir ..\include\jtalk 2>nul
+          mkdir ..\include\python-jtalk\htsengineapi 2>nul
+          mkdir ..\include\python-jtalk\libopenjtalk 2>nul
+          mkdir ..\source\synthDrivers\jtalk 2>nul
           call copy_jtalk_core_files.cmd
           if errorlevel 1 exit /b %errorlevel%
-      - name: Sync core trees into python-jtalk
-        shell: cmd
-        working-directory: miscDepsJp\jptools
-        run: |
-          call copy_jtalk_core_files.cmd
-          if errorlevel 1 exit /b %errorlevel%
+          endlocal
       - name: Verify HTS vendor tree
         shell: pwsh
         run: |
@@ -139,8 +140,15 @@ jobs:
         shell: cmd
         working-directory: miscDepsJp\jptools
         run: |
+          setlocal
+          set XCOPYCMD=/I /Y
+          mkdir ..\include\jtalk 2>nul
+          mkdir ..\include\python-jtalk\htsengineapi 2>nul
+          mkdir ..\include\python-jtalk\libopenjtalk 2>nul
+          mkdir ..\source\synthDrivers\jtalk 2>nul
           call copy_jtalk_core_files.cmd
           if errorlevel 1 exit /b %errorlevel%
+          endlocal
       - name: Build x64 libopenjtalk via SCons alias
         shell: cmd
         run: |

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -69,7 +69,9 @@ jobs:
           if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
             Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
             if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
-            git clone --depth 1 https://github.com/nvdajp/python-jtalk "$pj"
+            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
+            # Ensure submodules are populated (for safety on shallow clones)
+            git -C "$pj" submodule update --init --recursive --depth 1
           }
 
       - name: Sync core trees into python-jtalk

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -62,6 +62,26 @@ jobs:
           }
           patch --version | Select-Object -First 1
 
+      - name: Fetch python-jtalk vendor if missing
+        shell: pwsh
+        run: |
+          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
+          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
+            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
+            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
+            git clone --depth 1 https://github.com/nvdajp/python-jtalk "$pj"
+          }
+
+      - name: Sync core trees into python-jtalk
+        shell: pwsh
+        run: |
+          $root = $pwd
+          $src1 = Join-Path $root 'miscDepsJp/include/libopenjtalk'
+          $src2 = Join-Path $root 'miscDepsJp/include/htsengineapi'
+          $dst = Join-Path $root 'miscDepsJp/include/python-jtalk'
+          robocopy "$src1" (Join-Path $dst 'libopenjtalk') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          robocopy "$src2" (Join-Path $dst 'htsengineapi') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+
       - name: Adjust linker machine flag for x64
         if: matrix.arch == 'x64'
         shell: pwsh

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -45,6 +45,22 @@ jobs:
           python --version
           where patch || echo "patch not found in PATH"
 
+      - name: Ensure GNU patch available
+        shell: pwsh
+        run: |
+          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
+            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\\usr\\bin'
+            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
+          }
+          patch --version | Select-Object -First 1
+
+      - name: Adjust linker machine flag for x64
+        if: matrix.arch == 'x64'
+        shell: pwsh
+        working-directory: miscDepsJp/include/python-jtalk/lib
+        run: |
+          (Get-Content Makefile.mak -Raw) -replace '/MACHINE:x86','/MACHINE:X64' | Set-Content Makefile.mak -Encoding ASCII
+
       - name: Build libopenjtalk (nmake)
         shell: cmd
         working-directory: miscDepsJp\include\python-jtalk
@@ -64,4 +80,3 @@ jobs:
         with:
           name: miscDepsJp-${{ matrix.arch }}-artifacts
           path: _artifacts/**
-

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -95,149 +95,151 @@ jobs:
           Write-Host "[diag] Listing repo htsengineapi/lib"
           if (Test-Path miscDepsJp/include/htsengineapi/lib) { Get-ChildItem -Path miscDepsJp/include/htsengineapi/lib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
 
-      - name: Pre-build HTS engine (vendor or repo)
-        shell: pwsh
-        run: |
-          $vendorHts = Join-Path $pwd 'miscDepsJp/include/python-jtalk/htsengineapi'
-          $vendorLib = Join-Path $vendorHts 'lib'
-          $repoHts   = Join-Path $pwd 'miscDepsJp/include/htsengineapi'
-          $repoLib   = Join-Path $repoHts 'lib'
-
-          # ベンダーツリーが無ければ、リポ内の htsengineapi を vendor 配下に作成
-          if (-not (Test-Path $vendorHts) -and (Test-Path $repoHts)) {
-            Write-Host "[info] Creating vendor htsengineapi from repo copy"
-            robocopy "$repoHts" "$vendorHts" /E /NFL /NDL /NJH /NJS /NP | Out-Null
-          }
-
-          function Invoke-NMake($dir, $mk) {
-            Push-Location $dir
-            try { nmake /f $mk } finally { Pop-Location }
-          }
-
-          $builtFrom = $null
-          if (Test-Path (Join-Path $vendorLib 'Makefile.mak')) {
-            Invoke-NMake $vendorLib 'Makefile.mak'
-            $builtFrom = 'vendorLib'
-          } elseif (Test-Path (Join-Path $vendorHts 'Makefile.mak')) {
-            # ルートに Makefile.mak がある場合はそこでビルド
-            Invoke-NMake $vendorHts 'Makefile.mak'
-            $builtFrom = 'vendorRoot'
-          } elseif (Test-Path (Join-Path $repoLib 'Makefile.mak')) {
-            Invoke-NMake $repoLib 'Makefile.mak'
-            $builtFrom = 'repoLib'
-            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
-            Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
-            Get-ChildItem $repoLib -Filter *.obj | Copy-Item -Destination $vendorLib -Force
-          } elseif (Test-Path (Join-Path $repoHts 'Makefile.mak')) {
-            Invoke-NMake $repoHts 'Makefile.mak'
-            $builtFrom = 'repoRoot'
-            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
-            if (Test-Path (Join-Path $repoLib 'hts_engine_API.lib')) {
-              Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
-            }
-            if (Test-Path $repoLib) {
-              Get-ChildItem $repoLib -Filter *.obj -ErrorAction SilentlyContinue | Copy-Item -Destination $vendorLib -Force
-            }
-          } else {
-            throw "HTS Makefile not found in vendor or repo: $vendorHts ; $repoHts"
-          }
-          Write-Host "[info] HTS built from: $builtFrom"
-
+# removed brittle HTS pre-build (rely on all.mak)
       - name: Build libopenjtalk (nmake)
-        shell: cmd
-        working-directory: miscDepsJp\include\python-jtalk
-        run: |
-          nmake /f all.mak
 
-      - name: Collect artifacts
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path _artifacts | Out-Null
-          $dll = "miscDepsJp/include/python-jtalk/libopenjtalk.dll"
-          if (Test-Path $dll) { Copy-Item $dll _artifacts/libopenjtalk-x86.dll }
-          Get-ChildItem -Recurse -File miscDepsJp/include/python-jtalk | Out-File _artifacts/filelist-x86.txt
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: miscDepsJp-x86-artifacts
-          path: _artifacts/**
-
-  jp-tests:
-    name: JP unit tests (optional)
-    needs: miscdepsjp-x86
-    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-jp-tests')
-    runs-on: windows-2025
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.9'
-          architecture: x86
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x86
-      - name: Ensure GNU patch available
-        shell: pwsh
-        run: |
-          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
-            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\usr\bin'
-            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
+          Write-Host "[info] HTS built from: $builtFrom"
           }
-          patch --version | Select-Object -First 1
-      - name: Run JP tests via SCons
-        shell: pwsh
-        run: |
-          uv run scons miscdepsjp jpTests jpCharTests -j1
-      - name: Upload JP test logs
-        uses: actions/upload-artifact@v4
-        with:
-          name: jp-tests-logs
-          path: |
-            miscDepsJp/jptools/__test_log.txt
-            miscDepsJp/jptools/__jpBrailleHarness.md
-            miscDepsJp/jptools/jpBrailleHarness.html
+            throw "HTS Makefile not found in vendor or repo: $vendorHts ; $repoHts"
+          } else {
+            }
+              Get-ChildItem $repoLib -Filter *.obj -ErrorAction SilentlyContinue | Copy-Item -Destination $vendorLib -Force
+            if (Test-Path $repoLib) {
+            }
+              Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
+            if (Test-Path (Join-Path $repoLib 'hts_engine_API.lib')) {
+            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
+            $builtFrom = 'repoRoot'
+            Invoke-NMake $repoHts 'Makefile.mak'
+          } elseif (Test-Path (Join-Path $repoHts 'Makefile.mak')) {
+            Get-ChildItem $repoLib -Filter *.obj | Copy-Item -Destination $vendorLib -Force
+            Copy-Item (Join-Path $repoLib 'hts_engine_API.lib') $vendorLib -Force -ErrorAction Stop
+            New-Item -ItemType Directory -Force -Path $vendorLib | Out-Null
+            $builtFrom = 'repoLib'
+            Invoke-NMake $repoLib 'Makefile.mak'
+          } elseif (Test-Path (Join-Path $repoLib 'Makefile.mak')) {
+            $builtFrom = 'vendorRoot'
+            Invoke-NMake $vendorHts 'Makefile.mak'
+            # ルートに Makefile.mak がある場合はそこでビルド
+          } elseif (Test-Path (Join-Path $vendorHts 'Makefile.mak')) {
+            $builtFrom = 'vendorLib'
+            Invoke-NMake $vendorLib 'Makefile.mak'
+          if (Test-Path (Join-Path $vendorLib 'Makefile.mak')) {
+          $builtFrom = $null
 
-  miscdepsjp-x64:
-    name: Build miscDepsJp (x64 experimental)
-    needs: miscdepsjp-x86
-    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdeps64')
-    continue-on-error: true
-    runs-on: windows-2025
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.9'
-          architecture: x64
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-      - name: Ensure GNU patch available
-        shell: pwsh
-        run: |
-          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
-            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\usr\bin'
-            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
           }
-          patch --version | Select-Object -First 1
-      - name: Fetch python-jtalk vendor if missing
-        shell: pwsh
+            try { nmake /f $mk } finally { Pop-Location }
+            Push-Location $dir
+          function Invoke-NMake($dir, $mk) {
+
+          }
+            robocopy "$repoHts" "$vendorHts" /E /NFL /NDL /NJH /NJS /NP | Out-Null
+            Write-Host "[info] Creating vendor htsengineapi from repo copy"
+          if (-not (Test-Path $vendorHts) -and (Test-Path $repoHts)) {
+          # ベンダーツリーが無ければ、リポ内の htsengineapi を vendor 配下に作成
+
+          $repoLib   = Join-Path $repoHts 'lib'
+          $repoHts   = Join-Path $pwd 'miscDepsJp/include/htsengineapi'
+          $vendorLib = Join-Path $vendorHts 'lib'
+          $vendorHts = Join-Path $pwd 'miscDepsJp/include/python-jtalk/htsengineapi'
         run: |
-          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
-          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
-            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
-            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
-            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
+        shell: pwsh
+      - name: Pre-build HTS engine (vendor or repo)
+
+          if (Test-Path miscDepsJp/include/htsengineapi/lib) { Get-ChildItem -Path miscDepsJp/include/htsengineapi/lib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
+          Write-Host "[diag] Listing repo htsengineapi/lib"
+          if (Test-Path miscDepsJp/include/python-jtalk/htsengineapi) { Get-ChildItem -Path miscDepsJp/include/python-jtalk/htsengineapi | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
+          Write-Host "[diag] Listing python-jtalk/htsengineapi"
+          Get-ChildItem -Path miscDepsJp/include/python-jtalk | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
+          Write-Host "[diag] Listing python-jtalk"
+          Get-ChildItem -Path miscDepsJp/include | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host
+          Write-Host "[diag] Listing miscDepsJp/include"
+        run: |
+        shell: pwsh
+      - name: Diagnose tree (python-jtalk and htsengineapi)
+
+          if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { Write-Host "robocopy exit code aggregate: $max (treated as success)"; $global:LASTEXITCODE = 0 }
+          $max = [Math]::Max($code1, $code2)
+          $code2 = $LASTEXITCODE
+          robocopy "$src2" (Join-Path $dst 'htsengineapi') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          $code1 = $LASTEXITCODE
+          robocopy "$src1" (Join-Path $dst 'libopenjtalk') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          $dst = Join-Path $root 'miscDepsJp/include/python-jtalk'
+          $src2 = Join-Path $root 'miscDepsJp/include/htsengineapi'
+          $src1 = Join-Path $root 'miscDepsJp/include/libopenjtalk'
+          $root = $pwd
+        run: |
+        shell: pwsh
+      - name: Sync core trees into python-jtalk
+
+          }
             git -C "$pj" submodule update --init --recursive --depth 1
-          }
-      - name: Build x64 libopenjtalk via SCons alias
-        shell: pwsh
+            # Ensure submodules are populated (for safety on shallow clones)
+            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
+            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
+            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
+          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
+          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
         run: |
-          uv run scons miscdepsjp-x64 -j1
-      - name: Upload x64 artifacts
-        uses: actions/upload-artifact@v4
+        shell: pwsh
+      - name: Fetch python-jtalk vendor if missing
+
+          patch --version | Select-Object -First 1
+          }
+            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
+            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\\usr\\bin'
+          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
+        run: |
+        shell: pwsh
+      - name: Ensure GNU patch available
+
+          where patch || echo "patch not found in PATH"
+          python --version
+          nmake /? | Select-Object -First 1
+          cl 2>$null || echo "cl not found"
+        run: |
+        shell: pwsh
+      - name: Show toolchain
+
+          arch: x86
         with:
-          name: miscDepsJp-x64-artifacts
-          path: |
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Setup MSVC (x86)
+
+          architecture: x86
+          python-version: '3.11.9'
+        with:
+        uses: actions/setup-python@v5
+      - name: Setup Python 3.11.9 (x86)
+
+        uses: actions/checkout@v4
+      - name: Checkout
+    steps:
+      NMAKE: /nologo
+    env:
+    runs-on: windows-2025
+    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdepsjp')
+    # Run when dispatched manually, or when PR has the label 'run-miscdepsjp'.
+    name: Build miscDepsJp (x86 baseline)
+  miscdepsjp-x86:
+jobs:
+
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+
+  contents: read
+permissions:
+
+      - '.github/workflows/miscdepsjp-artifacts.yml'
+      - 'jptools/**'
+      - 'miscDepsJp/**'
+    paths:
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    branches: [ betajp ]
+  pull_request:
+  workflow_dispatch:
+on:
+
+name: JP miscDepsJp Artifacts (311 x86/x64)
             miscDepsJp/_build/libopenjtalk-x64.dll

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -64,6 +64,19 @@ jobs:
           $code2 = $LASTEXITCODE
           $max = [Math]::Max($code1, $code2)
           if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { $global:LASTEXITCODE = 0 }
+      - name: Verify HTS vendor tree
+        shell: pwsh
+        run: |
+          $htsLib = 'miscDepsJp/include/python-jtalk/htsengineapi/lib'
+          if (-not (Test-Path $htsLib)) { Write-Error ("missing: {0}" -f $htsLib); exit 1 }
+          Get-ChildItem $htsLib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host
+          if (-not (Test-Path (Join-Path $htsLib 'Makefile.mak'))) { Write-Error 'Makefile.mak missing in vendor htsengineapi/lib'; exit 1 }
+          if (-not (Test-Path (Join-Path $htsLib 'HTS_label.c'))) { Write-Error 'HTS_label.c missing in vendor htsengineapi/lib'; exit 1 }
+      - name: Build HTS engine (vendor)
+        shell: cmd
+        working-directory: miscDepsJp\include\python-jtalk\htsengineapi\lib
+        run: |
+          nmake /f Makefile.mak
       - name: Build HTS engine (vendor)
         shell: cmd
         working-directory: miscDepsJp\include\python-jtalk\htsengineapi\lib

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -7,6 +7,7 @@ on:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     paths:
       - 'miscDepsJp/**'
+      - 'jptools/**'
       - '.github/workflows/miscdepsjp-artifacts.yml'
 
 permissions:
@@ -17,33 +18,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build miscDepsJp (${{ matrix.arch }})
+  miscdepsjp-x86:
+    name: Build miscDepsJp (x86 baseline)
     # Run when dispatched manually, or when PR has the label 'run-miscdepsjp'.
     if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdepsjp')
     runs-on: windows-2025
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x86, x64]
-        python: ["3.11.9"]
     env:
-      # Make nmake verbose when we need to debug
       NMAKE: /nologo
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python ${{ matrix.python }} (${{ matrix.arch }})
+      - name: Setup Python 3.11.9 (x86)
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
-          architecture: ${{ matrix.arch }}
+          python-version: '3.11.9'
+          architecture: x86
 
-      - name: Setup MSVC (${{ matrix.arch }})
+      - name: Setup MSVC (x86)
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: ${{ matrix.arch }}
+          arch: x86
 
       - name: Show toolchain
         shell: pwsh
@@ -99,14 +94,6 @@ jobs:
           if (Test-Path miscDepsJp/include/python-jtalk/htsengineapi) { Get-ChildItem -Path miscDepsJp/include/python-jtalk/htsengineapi | Select-Object Name,Mode | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
           Write-Host "[diag] Listing repo htsengineapi/lib"
           if (Test-Path miscDepsJp/include/htsengineapi/lib) { Get-ChildItem -Path miscDepsJp/include/htsengineapi/lib | Select-Object Name,Length | Format-Table | Out-String -Width 2000 | Write-Host } else { Write-Host "(missing)" }
-
-      - name: Adjust linker machine flag for x64
-        if: matrix.arch == 'x64'
-        shell: pwsh
-        run: |
-          $p = Join-Path $pwd 'miscDepsJp/include/python-jtalk/lib/Makefile.mak'
-          if (-not (Test-Path $p)) { Get-ChildItem -Recurse -Directory miscDepsJp | Select-Object -First 20 | Format-List | Out-String | Write-Host; throw "Makefile not found: $p" }
-          (Get-Content $p -Raw) -replace '/MACHINE:x86','/MACHINE:X64' | Set-Content $p -Encoding ASCII
 
       - name: Pre-build HTS engine (vendor or repo)
         shell: pwsh
@@ -167,18 +154,18 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path _artifacts | Out-Null
           $dll = "miscDepsJp/include/python-jtalk/libopenjtalk.dll"
-          if (Test-Path $dll) { Copy-Item $dll _artifacts/libopenjtalk-${{ matrix.arch }}.dll }
-          Get-ChildItem -Recurse -File miscDepsJp/include/python-jtalk | Out-File _artifacts/filelist-${{ matrix.arch }}.txt
+          if (Test-Path $dll) { Copy-Item $dll _artifacts/libopenjtalk-x86.dll }
+          Get-ChildItem -Recurse -File miscDepsJp/include/python-jtalk | Out-File _artifacts/filelist-x86.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: miscDepsJp-${{ matrix.arch }}-artifacts
+          name: miscDepsJp-x86-artifacts
           path: _artifacts/**
 
   jp-tests:
     name: JP unit tests (optional)
-    needs: build
+    needs: miscdepsjp-x86
     if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-jp-tests')
     runs-on: windows-2025
     steps:
@@ -210,3 +197,47 @@ jobs:
             miscDepsJp/jptools/__test_log.txt
             miscDepsJp/jptools/__jpBrailleHarness.md
             miscDepsJp/jptools/jpBrailleHarness.html
+
+  miscdepsjp-x64:
+    name: Build miscDepsJp (x64 experimental)
+    needs: miscdepsjp-x86
+    if: github.event_name == 'workflow_dispatch' || contains(toJson(github.event.pull_request.labels), 'run-miscdeps64')
+    continue-on-error: true
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+          architecture: x64
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+      - name: Ensure GNU patch available
+        shell: pwsh
+        run: |
+          if (-not (Get-Command patch -ErrorAction SilentlyContinue)) {
+            $gitUsr = Join-Path ${env:ProgramFiles} 'Git\usr\bin'
+            if (Test-Path $gitUsr) { $env:PATH = "$gitUsr;" + $env:PATH }
+          }
+          patch --version | Select-Object -First 1
+      - name: Fetch python-jtalk vendor if missing
+        shell: pwsh
+        run: |
+          $pj = Join-Path $pwd 'miscDepsJp/include/python-jtalk'
+          if (-not (Test-Path (Join-Path $pj 'lib/Makefile.mak'))) {
+            Write-Host "[info] Cloning nvdajp/python-jtalk into $pj"
+            if (-not (Test-Path $pj)) { New-Item -ItemType Directory -Force -Path $pj | Out-Null }
+            git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/nvdajp/python-jtalk "$pj"
+            git -C "$pj" submodule update --init --recursive --depth 1
+          }
+      - name: Build x64 libopenjtalk via SCons alias
+        shell: pwsh
+        run: |
+          uv run scons miscdepsjp-x64 -j1
+      - name: Upload x64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: miscDepsJp-x64-artifacts
+          path: |
+            miscDepsJp/_build/libopenjtalk-x64.dll

--- a/.github/workflows/miscdepsjp-artifacts.yml
+++ b/.github/workflows/miscdepsjp-artifacts.yml
@@ -58,12 +58,19 @@ jobs:
           $src1 = Join-Path $root 'miscDepsJp/include/libopenjtalk'
           $src2 = Join-Path $root 'miscDepsJp/include/htsengineapi'
           $dst = Join-Path $root 'miscDepsJp/include/python-jtalk'
-          robocopy "$src1" (Join-Path $dst 'libopenjtalk') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          $dst1 = Join-Path $dst 'libopenjtalk'
+          $dst2 = Join-Path $dst 'htsengineapi'
+          New-Item -ItemType Directory -Force -Path $dst1 | Out-Null
+          New-Item -ItemType Directory -Force -Path $dst2 | Out-Null
+          # Try robocopy first (fast), then fallback to Copy-Item for reliability
+          robocopy "$src1" "$dst1" /E /NFL /NDL /NJH /NJS /NP | Out-Null
           $code1 = $LASTEXITCODE
-          robocopy "$src2" (Join-Path $dst 'htsengineapi') /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          robocopy "$src2" "$dst2" /E /NFL /NDL /NJH /NJS /NP | Out-Null
           $code2 = $LASTEXITCODE
           $max = [Math]::Max($code1, $code2)
-          if ($max -ge 8) { Write-Error "robocopy failed with code $max"; exit $max } else { $global:LASTEXITCODE = 0 }
+          if ($code1 -ge 8) { Copy-Item -Recurse -Force "$src1\*" $dst1 }
+          if ($code2 -ge 8) { Copy-Item -Recurse -Force "$src2\*" $dst2 }
+          if ($max -ge 8) { Write-Host "[warn] robocopy had errors (code=$max), used Copy-Item fallback"; $global:LASTEXITCODE = 0 }
       - name: Verify HTS vendor tree
         shell: pwsh
         run: |

--- a/jptools/scons_jp.py
+++ b/jptools/scons_jp.py
@@ -419,3 +419,93 @@ def register_jp_builders(env: Any) -> None:
     # Alias: certBuild (convenience umbrella alias)
     # Use string targets/aliases so resolution happens after upstream defines them.
     env.Alias("certBuild", [env.Alias("certprep"), "source", "user_docs", "dist", "launcher"])
+
+    # Alias: miscdepsjp-x64 (build libopenjtalk for x64 without touching vendor sources)
+    def _run_nmake(dir_path: Path, mk: str) -> int:
+        from subprocess import run
+        if not dir_path.exists():
+            print(f"Error: directory not found: {dir_path}")
+            return 1
+        res = run(["nmake", "/f", mk], cwd=str(dir_path))
+        return res.returncode
+
+    def _ensure_hts_prebuilt(vendor_root: Path, repo_root: Path) -> int:
+        """Build hts_engine_API.lib and required objects.
+
+        Try vendor/lib, vendor/, then repo/lib, repo/ (htsengineapi subtree).
+        """
+        vendor_hts = vendor_root / "htsengineapi"
+        repo_hts = repo_root / "miscDepsJp" / "include" / "htsengineapi"
+        # Prefer vendor/lib Makefile
+        candidates: list[tuple[Path, str]] = []
+        candidates.append((vendor_hts / "lib", "Makefile.mak"))
+        candidates.append((vendor_hts, "Makefile.mak"))
+        candidates.append((repo_hts / "lib", "Makefile.mak"))
+        candidates.append((repo_hts, "Makefile.mak"))
+        for d, mk in candidates:
+            if (d / mk).exists():
+                return _run_nmake(d, mk)
+        print(f"Error: HTS Makefile not found under {vendor_hts} or {repo_hts}")
+        return 1
+
+    def _build_openjtalk_x64(target: list[Any], source: list[Any], env: Any) -> int:
+        """Build x64 libopenjtalk via vendor Makefile with a temporary MACHINE flag change.
+
+        Outputs: miscDepsJp/_build/libopenjtalk-x64.dll
+        """
+        from subprocess import run
+        repo_root = Path.cwd()
+        vendor_root = repo_root / "miscDepsJp" / "include" / "python-jtalk"
+        if not vendor_root.exists():
+            print("Error: vendor python-jtalk not found. Clone into miscDepsJp/include/python-jtalk.")
+            return 1
+        # Ensure HTS vendor (or repo) is built first
+        rc = _ensure_hts_prebuilt(vendor_root, repo_root)
+        if rc != 0:
+            return rc
+        # Temporarily adjust MACHINE flag for x64 link
+        lib_dir = vendor_root / "lib"
+        mk_path = lib_dir / "Makefile.mak"
+        original_text = None
+        try:
+            if mk_path.exists():
+                original_text = mk_path.read_text(encoding="utf-8", errors="ignore")
+                patched = original_text.replace("/MACHINE:x86", "/MACHINE:X64")
+                mk_path.write_text(patched, encoding="utf-8")
+            else:
+                print(f"Warning: {mk_path} not found; proceeding without MACHINE patch")
+            # Build all
+            rc = _run_nmake(vendor_root, "all.mak")
+            if rc != 0:
+                return rc
+        finally:
+            # Restore original Makefile if we patched it
+            try:
+                if original_text is not None:
+                    mk_path.write_text(original_text, encoding="utf-8")
+            except Exception:
+                # Non-fatal restore failure
+                pass
+        # Copy resulting DLL to build output
+        out_dir = repo_root / "miscDepsJp" / "_build"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        built = vendor_root / "libopenjtalk.dll"
+        if not built.exists():
+            # Fallback: some trees leave DLL in lib/
+            alt = lib_dir / "libopenjtalk.dll"
+            if alt.exists():
+                built = alt
+        if not built.exists():
+            print("Error: libopenjtalk.dll not produced by build")
+            return 1
+        (out_dir / "libopenjtalk-x64.dll").write_bytes(built.read_bytes())
+        # Stamp
+        stamp_path = Path(str(target[0]))
+        stamp_path.parent.mkdir(parents=True, exist_ok=True)
+        stamp_path.write_text("ok", encoding="utf-8")
+        return 0
+
+    x64_stamp = env.File("miscDepsJp/_state/build/libopenjtalk-x64.stamp")
+    env.AlwaysBuild(x64_stamp)
+    env.Command(x64_stamp, [], _build_openjtalk_x64)
+    env.Alias("miscdepsjp-x64", x64_stamp)

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -149,6 +149,17 @@
 
 - Win32 ツール依存の棚卸しと縮退計画（nmake/cl/link/msgfmt/dump_syms 等）
 
+### 補足（miscDepsJp x64 / SCons / CI）
+
+- 既存維持: 既存の `miscdepsjp` と `libopenjtalk.dll` は変更しない（後方互換）。
+- 追加: SCons に `miscdepsjp-x64` エイリアスを追加し、x64 向けのビルド検証を実施（ベンダーツリーは不変更／リンク時のみ一時的に `/MACHINE:X64` を適用）。
+- 成果物: `miscDepsJp/_build/libopenjtalk-x64.dll`（成果物のみ。配布/署名なし）。
+- CI 方針（artifacts ワークフロー）:
+  - x86 ベースライン: ジョブ `miscdepsjp-x86`（ラベル `run-miscdepsjp`）
+  - x64 実験: ジョブ `miscdepsjp-x64`（ラベル `run-miscdeps64`、必要に応じて continue-on-error）
+  - JP ユニットテスト（任意）: ジョブ `jp-tests`（ラベル `run-jp-tests`）。SCons の `jpTests` / `jpCharTests` を実行し、ログをアーティファクト化。
+- 取得: `python-jtalk` はサブモジュール込みで取得（`--recurse-submodules`）。YAML 側は最小（SCons 呼び出し中心）。
+
 ## 運用ルール（ブランチ/PR）
 
 - `betajp` は安定ブランチ（直接 push 禁止）。すべてトピックブランチ→PR で変更。

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -41,16 +41,14 @@
 - CI を SCons で成立させ、.cmd 経由を可能な範囲で排除
 - SCons キャッシュ/引数の整合（ci/scripts/setSconsArgs.ps1 準拠）
 - Lint（ruff）ジョブ追加・安定化
-- 7z ラウンドトリップ除去（Python化）
 - ユニット/必要最小のシステムテストを安定して通す（installer タグは最小構成で運用可）
-- testAndPublish の主要ジョブを windows-2025 へ（後述: ランナー移行計画）
 - 上流追従容易化: testAndPublish.yml は上流原本を優先し、JP 固有はスクリプト呼び出しの最小パッチに集約
 - certBuild2023.cmd の動作は維持（署名はローカル実施）
 
 ### 作業方針（Step 1 実務）
 
 - ワークフロー再同期: testAndPublish.yml は本家 rc ベースに再同期し、差分は Step 1 固定（Windows 32‑bit / Python 3.11 (x86)）のみに限定する
-  - マトリクス固定: `defaultRunner: windows-2025`、`supportedArchitectures: ["x86"]`、`supportedPythonVersions: ["3.11.9"]`
+  - マトリクス固定: `supportedArchitectures: ["x86"]`、`supportedPythonVersions: ["3.11.9"]`
   - buildNVDA で必ず `scons source` を実行（unit tests に必要な生成物を用意）。直後に `beforeTests.ps1` を 1 回だけ実行
   - キャッシュ運用は本家に合わせ、path: `.` を `actions/cache/save/restore@v4` で保存・復元（キーに `run_id`・`pythonVersion`・`arch` を含める）
 - 後続ジョブ（typeCheck / checkPo / checkPot / licenseCheck / unitTests / createLauncher / systemTests / createSymbols）
@@ -64,6 +62,21 @@
   - すべてトピックブランチ→PR。`betajp` へ直 push は禁止（ブランチ保護と必須チェックを有効化）
   - YAML の差分は「3.11 x86 固定」と「スクリプト呼び出し 1 行」に限定。前処理・ログ収集は `ci/scripts/` に集約
   - 失敗時の診断性向上（翻訳/ライセンス/テスト結果のアーティファクト化、step summary 充実）は別 PR で段階導入
+
+### 既知の懸念
+
+- Python 3.13 への移行と x64 対応が、fast-diff-match-patch（DMP）依存の配布状況により同時対応になりうる。
+  - 対応方針（今は実装せず記録のみ）
+    - DMP 読み込み失敗時は difflib へ自動フォールバック（コード側で遅延 import/try-except）
+    - CI では 3.13 x64 を先行検証、3.13 x86 は typeCheck/lint のみ等で段階導入
+  - Phase 1 完了時点で再評価し、必要なら Phase 2 の計画に反映
+
+- 緩和策案（記録のみ・実装は任意）: 先に Python 3.11 x64 を CI 限定で検証し、x64 固有課題を切り出す
+  - 目的: 3.13 への移行前にアーキ依存の問題（DMP を含む）を早期発見
+  - 範囲: NVDA 本体は Step 1 の通り 3.11 x86 を維持。別ジョブで 3.11 x64 を「ビルド/静的検査」だけ実施
+  - CI 方針: `workflow_dispatch` もしくは条件変数で既定無効。`scons source` と typeCheck を対象（installer/署名/配布は行わない）
+  - 禁則: JAB 64bit の導入や本体の x64 切替は行わない（Step 1 の除外項目を遵守）
+  - 受け入れ: 2 連続グリーン＋ログ上で既知差分の説明可能性を確認。結果は Phase 2 計画に反映
 
 ## Phase 2 : Python 3.13 対応（Part of #530）
 
@@ -79,16 +92,7 @@
 - 補足（運用）
   - 目的: x64 を既定化に向け安定、3.13 を実用レベルへ（配布は段階導入）
   - CI マトリクス: 3.13 x64（必須）/ 3.11 x86（EOL まで保守用）/ 3.13 x86（typeCheck・lint のみ任意）
-  - DMP フォールバック: fast-diff-match-patch が利用不可の場合は difflib へ自動退避
   - 主要 JP アドオン（jtalk/kgs）を x64 で起動確認（任意）
-
-### 既知の懸念
-
-- Python 3.13 への移行と x64 対応が、fast-diff-match-patch（DMP）依存の配布状況により同時対応になりうる。
-  - 対応方針（今は実装せず記録のみ）
-    - DMP 読み込み失敗時は difflib へ自動フォールバック（コード側で遅延 import/try-except）
-    - CI では 3.13 x64 を先行検証、3.13 x86 は typeCheck/lint のみ等で段階導入
-  - Phase 1 完了時点で再評価し、必要なら Phase 2 の計画に反映
 
 ## Phase 3 : x64 ビルド対応（Part of #530）
 
@@ -113,29 +117,6 @@
 - 依存更新でのビルド破綻 → ピン見直し/段階導入
 - システムテストの不安定化 → タグ縮小・再試行の仕組み
 
-## ランナー移行計画（windows-2025）
-
-- 方針: 本家版と整合させるため、windows-2025 へ段階移行。影響の小さいジョブから先行し、安定確認後に固定。
-- 移行順序（Phase 1 内で実施）
-  - フェーズ1-A（低リスク先行）
-    - 対象: typeCheck（pyright）、checkPo、checkPot、licenseCheck
-    - 方針: 直ちに windows-2025 へ。3 連続グリーンで固定
-  - フェーズ1-B（ビルド要所）
-    - 対象: buildNVDA、createLauncher、createSymbols
-    - 方針: SCons MSVC 設定キャッシュ（SCONS_CACHE_MSVC_CONFIG）を有効化してから 2025 へ。
-      2 連続グリーン＋成果物検証（launcher 起動・symbols 生成）で固定
-  - フェーズ1-C（最後に移行）
-    - 対象: unitTests → systemTests の順
-    - 方針: unitTests を先に 2025 へ。systemTests はタグを限定（例: startupShutdown）で試行→安定後に拡大
-- 受け入れ基準（各段）
-  - 2〜3 連続グリーン（ジョブ特性に応じて調整）
-  - 成果物の基本動作確認（launcher 起動、symbols 正常作成/アップロード）
-  - 実行時間が顕著に悪化しない（悪化時はキャッシュ/並列度を見直し）
-- ロールバック/安全策
-  - 一時的にランナーをマトリクス化（windows-2022/2025 並走）して比較
-  - 不安定な場合は該当ジョブのみ即座に元のランナーへ戻す
-  - systemTests はタグ縮小・再試行の運用でフレークを抑制
-
 ## ゲート（判断ポイント）
 
 - Gate A（Phase 2 中間）: 3.13 x64 で unit + 最小 system が安定緑 → installer/署名/シンボル確認へ
@@ -144,14 +125,29 @@
 
 ## 現在の作業キュー（Step 1, refs #539）
 
-- PR #548（ドラフト）: CI 安定化フォローアップ（unit / license / translator）
-  - unit tests: `nvda-misc-deps`（editable）をテスト実行環境へ組み込み（rununittests.bat の `uv --group dev --group unit-tests`）
-  - license check: `testOutput/license` 事前作成＋結果をアーティファクトへ
-  - translator comments: ログ（translationCheckResults.log）をアーティファクトへ
-  - system tests: インストーラ導入前に `beforeTests.ps1` を実行（ディレクトリ作成）
+- CI 安定化フォローアップ（小粒PRで段階適用）
+  - unit: `rununittests.bat` で `uv --group dev --group unit-tests` を使用し、`nvda-misc-deps`（editable）を読み込む
+  - license: `testOutput/license` を事前作成し、チェック結果をアーティファクト化
+  - translator: `translationCheckResults.log` をアーティファクト化
+  - system: インストーラ導入前に `ci/scripts/beforeTests.ps1` を実行して `testOutput/` を作成
 
-- miscDepsJp（jtalk周辺）の patch.exe 依存の撤去（Makefile/all.mak の `patch` 呼び出しを純 Python 実装に置換）
-- Win32 ツール依存の棚卸しと縮退計画（nmake/cl/link/msgfmt/7z/dump_syms 等）
+- ワークフロー再同期（testAndPublish.yml）
+  - 上流 rc を取り込み、JP 追加は `# BEGIN JP PATCH`〜`# END JP PATCH` に最小集約
+  - マトリクス固定を確認: `supportedArchitectures: ["x86"]`、`supportedPythonVersions: ["3.11.9"]`
+  - 前後処理は `ci/scripts/` に寄せ、YAML 側はスクリプト呼び出しのみ（cache は `actions/cache@v4` を使用し、キーに `run_id`/`pythonVersion`/`arch` を含める）
+
+- 3.11 x64 事前検証（CI限定・配布なし）
+  - 対象: `scons source` と typeCheck のみ（installer/署名/配布は対象外）
+  - 実行: 既定無効（`workflow_dispatch`/条件変数で手動実行）
+  - 禁則: JAB 64bit の導入や NVDA 本体の x64 切替は行わない（Step 1 の除外を遵守）
+
+- miscDepsJp の x86/x64 マトリクス先行（3.13 前の準備）
+  - 目的: 依存（jtalk 周辺）のアーキ対応を先に固める。NVDA 本体は Step 1 の範囲（3.11 x86）を維持
+  - CI: 独立ジョブ（`strategy.matrix: arch: [x86, x64], python: ["3.11.9"]`）、成果物のみ作成（配布/署名は行わない）
+  - 成果物: `miscDepsJp-<arch>.zip` をアーティファクト化し、アーキ名を明示
+  - 禁則: NVDA 本体の x64 切替は行わない（Step 1 の除外範囲を遵守）
+
+- Win32 ツール依存の棚卸しと縮退計画（nmake/cl/link/msgfmt/dump_syms 等）
 
 ## 運用ルール（ブランチ/PR）
 


### PR DESCRIPTION
目的
- Step 1 の目的（3.11 x86 維持・上流整合・SCons/純Python優先）
- Step 1 の範囲で日本語版のロードマップを整理し、本家寄せに向けた記述の明確化（CI/配布に影響なし、ドキュメントのみ）
- dispatch専用の miscDepsJp x86/x64 アーティファクト生成ワークフローの雛形追加
- 署名/配布/Secrets は使用しない

変更点
- ランナー固有表記の削除（windows-2022/2025, defaultRunner 等）
- patch.exe（純Python移行）/ 7z ラウンドトリップの個別タスクを削除（必須ではないため）
- 既知の懸念（DMP 周り等）を Phase 1 内に移動し、扱いを「記録のみ」に整理
- 3.11 x64 事前検証（CI 限定・配布なし）の実験項目を追加（本体は 3.11 x86 維持）
- miscDepsJp の x86/x64 マトリクス先行（成果物のみ）の準備タスクを追加
- 3.11 x64 実験は「workflow_dispatch 等で既定無効、配布なし」の前提

refs #539