### PR TITLE
rollback: restore JTalk baseline (refs #539)

### DIFF
--- a/jptools/certBuild2023.cmd
+++ b/jptools/certBuild2023.cmd
@@ -1,4 +1,4 @@
-﻿setlocal enableextensions enabledelayedexpansion
+setlocal enableextensions enabledelayedexpansion
 set SCONSOPTIONS=%*
 if not defined SCONSOPTIONS (
     set SCONSOPTIONS=version_build=1 --all-cores
@@ -20,25 +20,54 @@ rem Timestamp server (override via env if needed)
 if defined TIMESERVER if not defined TIMESTAMP_URL set TIMESTAMP_URL=%TIMESERVER%
 if not defined TIMESTAMP_URL set TIMESTAMP_URL=http://timestamp.digicert.com
 
-rem Change to script directory (also switches drive)
+call miscDepsJp\include\python-jtalk\vcsetup.cmd
 cd /d %~dp0
-rem Then go up to repository root
 cd ..
+
+call jptools\check_vs_version.cmd
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+nmake /?
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+patch -v
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+cd miscDepsJp\jptools
+call copy_jtalk_core_files.cmd
+call build-and-test.cmd
+@if not "%ERRORLEVEL%"=="0" goto onerror
+cd ..\..
+
+call jptools\setupMiscDepsJp.cmd
 
 rem Resolve signtool path (allow override)
 if not defined SIGNTOOL set SIGNTOOL=C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe
 
-rem JP PATCH: store certificate only (PFX unsupported). Ensure CERT_STORE default.
+rem Build signing args similar to NVDA build\prepare.cmd
 if not defined CERT_STORE set CERT_STORE=My
+set "SIGN_ARGS=/fd SHA256 /td SHA256 /tr !TIMESTAMP_URL!"
 
-rem Prefer specific certificate by SHA1; else try auto-detect a valid trusted code signing cert
-if not defined CERT_SHA1 if not defined CERT_NAME (
+rem Prefer specific certificate by SHA1 or Name; else try auto-detect a valid trusted code signing cert
+if defined CERT_SHA1 (
+    set "SIGN_ARGS=!SIGN_ARGS! /s !CERT_STORE! /sha1 !CERT_SHA1!"
+    if defined CERT_MACHINE_STORE set "SIGN_ARGS=!SIGN_ARGS! /sm"
+) else if defined CERT_NAME (
+    set "SIGN_ARGS=!SIGN_ARGS! /s !CERT_STORE! /n !CERT_NAME!"
+    if defined CERT_MACHINE_STORE set "SIGN_ARGS=!SIGN_ARGS! /sm"
+) else (
     for /f "usebackq delims=" %%T in (`pwsh -NoProfile -Command "$stores=@('Cert:\\CurrentUser\\My','Cert:\\LocalMachine\\My'); $c=Get-ChildItem $stores -CodeSigningCert -ErrorAction SilentlyContinue | Where-Object { $_.HasPrivateKey -and $_.NotBefore -lt (Get-Date) -and $_.NotAfter -gt (Get-Date) } | Sort-Object NotAfter -Descending; if(-not $c){ exit 2 }; $chain=New-Object System.Security.Cryptography.X509Certificates.X509Chain; $chain.ChainPolicy.RevocationMode='NoCheck'; $chain.ChainPolicy.RevocationFlag='EntireChain'; $chain.ChainPolicy.VerificationFlags='NoFlag'; $chosen=$null; foreach($cert in $c){ if($chain.Build($cert)){ $chosen=$cert; break } }; if($null -eq $chosen){ exit 3 }; $chosen.Thumbprint.Replace(' ','')"`) do set "CERT_SHA1=%%T"
     if not defined CERT_SHA1 (
         echo [ERROR] No trusted code signing certificate detected.>&2
         echo         Set CERT_SHA1 or CERT_NAME to select the correct certificate.>&2
         goto onerror
     )
+    set "SIGN_ARGS=!SIGN_ARGS! /s !CERT_STORE! /sha1 !CERT_SHA1!"
+)
+
+rem Ensure /sm is set if CERT_MACHINE_STORE requested
+if defined CERT_MACHINE_STORE (
+    echo !SIGN_ARGS! | findstr /i /c:" /sm" >nul || set "SIGN_ARGS=!SIGN_ARGS! /sm"
 )
 
 echo Using signtool: %SIGNTOOL%
@@ -46,10 +75,50 @@ if defined CERT_SHA1 echo Using certificate (SHA1): !CERT_SHA1!
 if defined CERT_NAME echo Using certificate (Name): !CERT_NAME!
 echo Timestamp: !TIMESTAMP_URL!
 
+call :sign_one source\synthDrivers\jtalk\libmecab.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one source\synthDrivers\jtalk\libopenjtalk.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one miscDeps\python\brlapi-0.8.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one miscDeps\python\libgcc_s_dw2-1.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one miscDeps\source\brailleDisplayDrivers\lilli.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one .venv\Lib\site-packages\wx\wxbase32u_net_vc140.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one .venv\Lib\site-packages\wx\wxbase32u_vc140.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one .venv\Lib\site-packages\wx\wxmsw32u_core_vc140.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one .venv\Lib\site-packages\wx\wxmsw32u_html_vc140.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+call :sign_one .venv\Lib\site-packages\wx\wxmsw32u_stc_vc140.dll
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
 set SCONSARGS=certFile=1 certTimestampServer=%TIMESTAMP_URL% version=%VERSION% updateVersionType=%UPDATEVERSIONTYPE% %SCONSOPTIONS%
 
-rem JP PATCH: call SCons targets (JP additions included)
-call scons.bat certprep source user_docs launcher controllerClient jtalkAddon kgsAddon jpTests jpCharTests release=%RELEASE% publisher=%PUBLISHER% %SCONSARGS%
+call scons.bat source user_docs launcher release=%RELEASE% publisher=%PUBLISHER% %SCONSARGS%
+@if not "%ERRORLEVEL%"=="0" goto onerror
+
+cd jptools
+call pack_jtalk_addon.cmd
+call pack_kgs_addon.cmd
+cd ..
+call jptools\buildControllerClient.cmd %SCONSARGS%
+set PYTHONUTF8=1
+call jptools\tests.cmd
+@if not "%ERRORLEVEL%"=="0" goto onerror
+call jpchar\tests.cmd
 @if not "%ERRORLEVEL%"=="0" goto onerror
 
 set VERIFYLOG=output\nvda_%VERSION%_verify.log
@@ -86,3 +155,27 @@ exit /b 0
 echo nvdajp build error %ERRORLEVEL%
 @if "%PAUSE%"=="1" pause
 exit /b -1
+
+rem Subroutine: sign one file with retries and pause
+:sign_one
+setlocal enableextensions enabledelayedexpansion
+set "_FILE=%~1"
+if not exist "%_FILE%" (
+    echo [ERROR] File not found: %_FILE%>&2
+    endlocal & exit /b 1
+)
+set "_TRIES=0"
+:_try_sign
+set /a _TRIES+=1 >nul
+echo Signing "!_FILE!" (try !_TRIES!)
+"%SIGNTOOL%" sign !SIGN_ARGS! "!_FILE!"
+if "%ERRORLEVEL%"=="0" (
+    timeout /T 5 /NOBREAK >nul
+    endlocal & exit /b 0
+)
+if %_TRIES% LSS 3 (
+    timeout /T 1 /NOBREAK >nul
+    goto _try_sign
+)
+echo [ERROR] signtool sign failed for %_FILE%>&2
+endlocal & exit /b 1

--- a/jptools/certBuild2023.cmd
+++ b/jptools/certBuild2023.cmd
@@ -1,4 +1,4 @@
-setlocal enableextensions enabledelayedexpansion
+﻿setlocal enableextensions enabledelayedexpansion
 set SCONSOPTIONS=%*
 if not defined SCONSOPTIONS (
     set SCONSOPTIONS=version_build=1 --all-cores
@@ -49,9 +49,6 @@ echo Timestamp: !TIMESTAMP_URL!
 set SCONSARGS=certFile=1 certTimestampServer=%TIMESTAMP_URL% version=%VERSION% updateVersionType=%UPDATEVERSIONTYPE% %SCONSOPTIONS%
 
 rem JP PATCH: call SCons targets (JP additions included)
-rem Ensure jtalk fallback payload + overlay via SCons aliases
-call scons.bat -Q jtalkPrep miscdepsjp
-
 call scons.bat certprep source user_docs launcher controllerClient jtalkAddon kgsAddon jpTests jpCharTests release=%RELEASE% publisher=%PUBLISHER% %SCONSARGS%
 @if not "%ERRORLEVEL%"=="0" goto onerror
 

--- a/jptools/nonCertBuild.py
+++ b/jptools/nonCertBuild.py
@@ -330,11 +330,6 @@ def main() -> int:
 
     # Parse args; only forward ones after "--" to SCons
     raw_args = sys.argv[1:]
-    # Simple option handling without argparse to keep dependencies minimal
-    prep_only = False
-    if "--prep-only" in raw_args:
-        raw_args.remove("--prep-only")
-        prep_only = True
     if "--" in raw_args:
         sep = raw_args.index("--")
         forwarded_args = raw_args[sep + 1 :]
@@ -342,8 +337,6 @@ def main() -> int:
         forwarded_args = raw_args
 
     _prep_miscdepsjp()
-    if prep_only:
-        return 0
     _build_with_scons(forwarded_args)
     return 0
 

--- a/jptools/scons_jp.py
+++ b/jptools/scons_jp.py
@@ -196,8 +196,8 @@ def _sign_in_place(target: list[Any], source: list[Any], env: Any) -> int:
         print(f"JP certprep skipped non-PE file: {abspath}")
         return 0
     if not os.path.isfile(abspath):
-        print(f"Warning: file not found for signing, skipping: {abspath}")
-        return 0
+        print(f"Error: file not found for signing: {abspath}")
+        return 1
     # Delegate to upstream signing action
     retval = signExec([src], source, env)
     if retval != 0:
@@ -208,34 +208,6 @@ def _sign_in_place(target: list[Any], source: list[Any], env: Any) -> int:
     stamp_path.write_text("ok", encoding="utf-8")
     return 0
 
-
-def _sign_optional_path(target: list[Any], source: list[Any], env: Any, path: str) -> int:
-    """Sign file at `path` if it exists; otherwise skip and write a stamp.
-
-    This is tolerant of missing inputs so certprep can run before all payloads
-    are present. Intended only for local convenience.
-    """
-    signExec = env.get("signExec")
-    stamp_path = Path(str(target[0]))
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    if not signExec:
-        print("JP certprep skipped: signing not configured (set certFile or apiSigningToken)")
-        stamp_path.write_text("skip:no-sign-config", encoding="utf-8")
-        return 0
-    if not os.path.isfile(path):
-        print(f"Warning: file not found for signing, skipping: {path}")
-        stamp_path.write_text("skip:not-found", encoding="utf-8")
-        return 0
-    try:
-        node = env.File(path)
-        retval = signExec([node], [node], env)
-        if retval != 0:
-            return retval
-    except Exception as e:
-        print(f"Error: signing failed for {path}: {e}")
-        return 1
-    stamp_path.write_text("ok", encoding="utf-8")
-    return 0
 
 def _compute_overlay_targets(repo_root: Path) -> list[str]:
     """Return absolute paths for files overlaid from miscDepsJp/source -> source.
@@ -298,33 +270,6 @@ def register_jp_builders(env: Any) -> None:
     except Exception:
         pass
 
-    # Alias: jtalkPrep (ensure JP jtalk payload is present before overlay)
-    def _ensure_jtalk_payload(target: list[Any], source: list[Any], env: Any) -> int:
-        repo_root = Path.cwd()
-        src_prebuilt = repo_root / "miscDepsJp" / "include" / "python-jtalk" / "libopenjtalk.dll"
-        dst_payload = repo_root / "miscDepsJp" / "source" / "synthDrivers" / "jtalk" / "libopenjtalk.dll"
-        try:
-            dst_payload.parent.mkdir(parents=True, exist_ok=True)
-            if not dst_payload.exists() and src_prebuilt.exists():
-                dst_payload.write_bytes(src_prebuilt.read_bytes())
-        except Exception as e:
-            print(f"Warning: jtalkPrep fallback copy failed: {e}")
-            # Non-fatal; overlay/signing may skip if missing
-        Path(str(target[0])).parent.mkdir(parents=True, exist_ok=True)
-        Path(str(target[0])).write_text("ok", encoding="utf-8")
-        return 0
-
-    jtalk_prep_stamp = env.File("miscDepsJp/_state/prep/jtalkPrep.stamp")
-    env.AlwaysBuild(jtalk_prep_stamp)
-    env.Command(jtalk_prep_stamp, [], _ensure_jtalk_payload)
-    env.Alias("jtalkPrep", jtalk_prep_stamp)
-
-    # Ensure overlay runs after jtalkPrep so fallback payload is included
-    try:
-        env.Depends(env.Alias("miscdepsjp"), env.Alias("jtalkPrep"))
-    except Exception:
-        pass
-
     # Alias: controllerClient (zip artifact)
     out_dir = str(env.get("outputDir", "output"))
     version = str(env.get("version", "local"))
@@ -367,19 +312,10 @@ def register_jp_builders(env: Any) -> None:
     # It relies on upstream signExec (certFile/apiSigningToken) and remains a no-op
     # when signing is not configured (e.g., CI).
     def _signtarget(relpath: str) -> Any:
-        src_path = str(repo_root / relpath)
-        src_name = Path(src_path).name
-        stamp = env.File(f"miscDepsJp/_state/sign/{src_name}.stamp")
-        # Use an action that tolerates missing files and writes the stamp either way.
-        def _cb(target, source, env, p=src_path):
-            return _sign_optional_path(target, source, env, p)
-        env.Command(stamp, [], _cb)
-        # Ensure the JP overlay runs before signing so files exist in-place
-        try:
-            env.Depends(stamp, env.Alias("miscdepsjp"))
-        except Exception as e:
-            # Be conservative if alias lookup fails in early phases
-            print(f"Warning: Could not establish dependency for {stamp}: {e}")
+        src = repo_root / relpath
+        stamp = env.File(f"miscDepsJp/_state/sign/{src.name}.stamp")
+        # Stamp depends on the source file and the signing action writes the stamp
+        env.Command(stamp, env.File(str(src)), _sign_in_place)
         return stamp
 
     sign_list = [
@@ -408,8 +344,6 @@ def register_jp_builders(env: Any) -> None:
     try:
         if env.get("certFile") or env.get("apiSigningToken"):
             env.Depends(env.Alias("certprep"), env.Alias("miscdepsjp"))
-            # Run jtalkPrep before overlay/certprep so libopenjtalk.dll can be picked up
-            env.Depends(env.Alias("certprep"), env.Alias("jtalkPrep"))
             env.Depends("dist", env.Alias("certprep"))
             env.Depends("launcher", env.Alias("certprep"))
     except Exception as e:
@@ -419,3 +353,4 @@ def register_jp_builders(env: Any) -> None:
     # Alias: certBuild (convenience umbrella alias)
     # Use string targets/aliases so resolution happens after upstream defines them.
     env.Alias("certBuild", [env.Alias("certprep"), "source", "user_docs", "dist", "launcher"])
+

--- a/jptools/scons_jp.py
+++ b/jptools/scons_jp.py
@@ -16,10 +16,6 @@ Terminology:
 Aliases added:
 - miscdepsjp: Runs jptools/setup_miscdeps_overlay.py and writes a stamp file.
 - controllerClient: Builds NVDA controller client zip using pack_controller_client.py.
-- certprep: Signs pre-existing JP DLLs using env["signExec"].
-  Requires signing to be configured (e.g., `certFile` or `apiSigningToken`).
-  Intended for local builds only; CI should not enable this.
-- certBuild: Convenience alias that runs `certprep` + `source user_docs dist launcher`.
 
 These are intentionally light-weight and safe; wiring them into other
 targets can be done in later phases when stable.
@@ -64,22 +60,6 @@ def _pack_controller_client(target: list[Any], source: list[Any], env: Any) -> i
     # Prefer explicit version from env; fallback to empty (script uses 'local').
     version = str(env.get("version", ""))
     out_path = Path(str(target[0]))
-    # Sync built client artifacts from extras/controllerClient to jptools/nvdajpClient
-    try:
-        src_root = repo_root / "extras" / "controllerClient"
-        dst_root = repo_root / "jptools" / "nvdajpClient"
-        for arch in ("x86", "x64", "arm64"):
-            s = src_root / arch
-            d = dst_root / arch
-            if not s.exists():
-                continue
-            d.mkdir(parents=True, exist_ok=True)
-            for p in s.iterdir():
-                if p.is_file():
-                    (d / p.name).write_bytes(p.read_bytes())
-    except Exception as e:
-        # Non-fatal; packaging may still succeed if files already present
-        print(f"Warning: Failed to sync controller client artifacts: {e}")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     cmd = [
         sys.executable,
@@ -93,120 +73,6 @@ def _pack_controller_client(target: list[Any], source: list[Any], env: Any) -> i
     ]
     res = run(cmd)
     return res.returncode
-
-
-def _pack_jtalk_addon(target: list[Any], source: list[Any], env: Any) -> int:
-    repo_root = Path.cwd()
-    script = repo_root / "jptools" / "pack_jtalk_addon.py"
-    if not script.exists():
-        return 0
-    from subprocess import run
-    # Ensure VERSION is available for the packer (used for current date default)
-    version = str(env.get("version", ""))
-    run_env = os.environ.copy()
-    if version:
-        run_env["VERSION"] = version
-    res = run([sys.executable, str(script)], env=run_env)
-    if res.returncode != 0:
-        return res.returncode
-    # Stamp success
-    stamp_path = Path(str(target[0]))
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text("ok", encoding="utf-8")
-    return 0
-
-
-def _pack_kgs_addon(target: list[Any], source: list[Any], env: Any) -> int:
-    repo_root = Path.cwd()
-    script = repo_root / "jptools" / "pack_kgs_addon.py"
-    if not script.exists():
-        return 0
-    from subprocess import run
-    version = str(env.get("version", ""))
-    cmd = [sys.executable, str(script)]
-    if version:
-        cmd += ["--version", version]
-    res = run(cmd)
-    if res.returncode != 0:
-        return res.returncode
-    stamp_path = Path(str(target[0]))
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text("ok", encoding="utf-8")
-    return 0
-
-
-def _run_jp_tests(target: list[Any], source: list[Any], env: Any) -> int:
-    """Run JP dictionary tests similarly to jptools/tests.cmd.
-    - Compile ja .po to .mo using msgfmt
-    - Run jpDicTest.py
-    """
-    repo_root = Path.cwd()
-    msgfmt = repo_root / "miscDeps" / "tools" / "msgfmt.exe"
-    po = repo_root / "source" / "locale" / "ja" / "LC_MESSAGES" / "nvda.po"
-    mo = repo_root / "source" / "locale" / "ja" / "LC_MESSAGES" / "nvda.mo"
-    from subprocess import run
-
-    if msgfmt.exists() and po.exists():
-        res = run([str(msgfmt), str(po), "-o", str(mo)])
-        if res.returncode != 0:
-            return res.returncode
-    # Run jpDicTest.py from jptools directory
-    test_script = repo_root / "jptools" / "jpDicTest.py"
-    if test_script.exists():
-        res = run([sys.executable, str(test_script)], cwd=str(test_script.parent))
-        if res.returncode != 0:
-            return res.returncode
-    # Stamp success
-    Path(str(target[0])).parent.mkdir(parents=True, exist_ok=True)
-    Path(str(target[0])).write_text("ok", encoding="utf-8")
-    return 0
-
-
-def _run_jpchar_tests(target: list[Any], source: list[Any], env: Any) -> int:
-    """Run JP char description tests similarly to jpchar/tests.cmd."""
-    repo_root = Path.cwd()
-    script = repo_root / "jpchar" / "checkCharDesc.py"
-    from subprocess import run
-    if script.exists():
-        res = run([sys.executable, str(script)], cwd=str(script.parent))
-        if res.returncode != 0:
-            return res.returncode
-    Path(str(target[0])).parent.mkdir(parents=True, exist_ok=True)
-    Path(str(target[0])).write_text("ok", encoding="utf-8")
-    return 0
-
-
-def _sign_in_place(target: list[Any], source: list[Any], env: Any) -> int:
-    """Sign a pre-existing file (source[0]) in-place using env["signExec"].
-    Writes a small stamp file on success.
-
-    - Expects signing to be configured in the environment (certFile/apiSigningToken),
-      which is already wired by upstream sconstruct.
-    - Follows the retry/selection behavior implemented in upstream signExec.
-    """
-    # Do not crash if signing is not configured; provide a helpful message.
-    signExec = env.get("signExec")
-    if not signExec:
-        print("JP certprep skipped: signing not configured (set certFile or apiSigningToken)")
-        return 0
-    src = source[0]
-    abspath = src.abspath
-    # Ensure only PE images are passed through
-    if not abspath.lower().endswith((".dll", ".exe")):
-        print(f"JP certprep skipped non-PE file: {abspath}")
-        return 0
-    if not os.path.isfile(abspath):
-        print(f"Error: file not found for signing: {abspath}")
-        return 1
-    # Delegate to upstream signing action
-    retval = signExec([src], source, env)
-    if retval != 0:
-        return retval
-    # Stamp
-    stamp_path = Path(str(target[0]))
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text("ok", encoding="utf-8")
-    return 0
 
 
 def _compute_overlay_targets(repo_root: Path) -> list[str]:
@@ -276,81 +142,4 @@ def register_jp_builders(env: Any) -> None:
     cc_zip = env.File(os.path.join(out_dir, f"nvda_{version}_controllerClientJp.zip"))
     env.Command(cc_zip, [], _pack_controller_client)
     env.Alias("controllerClient", cc_zip)
-    # Ensure controller client binaries are built before packaging JP zip.
-    try:
-        for arch in ("x86", "x64", "arm64"):
-            dll = env.File(os.path.join("extras", "controllerClient", arch, "nvdaControllerClient.dll"))
-            hdr = env.File(os.path.join("extras", "controllerClient", arch, "nvdaController.h"))
-            env.Depends(cc_zip, [dll, hdr])
-    except Exception as e:
-        print(f"Warning: Could not set controller client dependencies: {e}")
-
-    # Aliases: jtalkAddon / kgsAddon (package JP add-ons)
-    jtalk_stamp = env.File("miscDepsJp/_state/addons/jtalkAddon.stamp")
-    env.AlwaysBuild(jtalk_stamp)
-    env.Command(jtalk_stamp, [], _pack_jtalk_addon)
-    env.Alias("jtalkAddon", jtalk_stamp)
-
-    kgs_stamp = env.File("miscDepsJp/_state/addons/kgsAddon.stamp")
-    env.AlwaysBuild(kgs_stamp)
-    env.Command(kgs_stamp, [], _pack_kgs_addon)
-    env.Alias("kgsAddon", kgs_stamp)
-
-    # Aliases: jpTests / jpCharTests
-    jp_tests_stamp = env.File("miscDepsJp/_state/tests/jpTests.stamp")
-    env.AlwaysBuild(jp_tests_stamp)
-    env.Command(jp_tests_stamp, [], _run_jp_tests)
-    env.Alias("jpTests", jp_tests_stamp)
-
-    jp_char_tests_stamp = env.File("miscDepsJp/_state/tests/jpCharTests.stamp")
-    env.AlwaysBuild(jp_char_tests_stamp)
-    env.Command(jp_char_tests_stamp, [], _run_jpchar_tests)
-    env.Alias("jpCharTests", jp_char_tests_stamp)
-
-    # Alias: certprep (sign pre-existing JP DLLs in-place)
-    # Note: This intentionally signs inputs which are later packaged into the dist.
-    # It relies on upstream signExec (certFile/apiSigningToken) and remains a no-op
-    # when signing is not configured (e.g., CI).
-    def _signtarget(relpath: str) -> Any:
-        src = repo_root / relpath
-        stamp = env.File(f"miscDepsJp/_state/sign/{src.name}.stamp")
-        # Stamp depends on the source file and the signing action writes the stamp
-        env.Command(stamp, env.File(str(src)), _sign_in_place)
-        return stamp
-
-    sign_list = [
-        # JP jtalk DLLs
-        "source/synthDrivers/jtalk/libmecab.dll",
-        "source/synthDrivers/jtalk/libopenjtalk.dll",
-        # miscDeps runtime DLLs
-        "miscDeps/python/brlapi-0.8.dll",
-        "miscDeps/python/libgcc_s_dw2-1.dll",
-        # braille driver binary shipped in miscDeps
-        "miscDeps/source/brailleDisplayDrivers/lilli.dll",
-        # wx widgets DLLs from the venv
-        ".venv/Lib/site-packages/wx/wxbase32u_net_vc140.dll",
-        ".venv/Lib/site-packages/wx/wxbase32u_vc140.dll",
-        ".venv/Lib/site-packages/wx/wxmsw32u_core_vc140.dll",
-        ".venv/Lib/site-packages/wx/wxmsw32u_html_vc140.dll",
-        ".venv/Lib/site-packages/wx/wxmsw32u_stc_vc140.dll",
-    ]
-    certprep_stamps: list[Any] = []
-    for rel in sign_list:
-        certprep_stamps.append(_signtarget(rel))
-    env.Alias("certprep", certprep_stamps)
-
-    # If signing is enabled (certFile/apiSigningToken set), ensure ordering:
-    #  miscdepsjp (overlay) -> certprep (sign DLLs in place) -> dist/launcher
-    try:
-        if env.get("certFile") or env.get("apiSigningToken"):
-            env.Depends(env.Alias("certprep"), env.Alias("miscdepsjp"))
-            env.Depends("dist", env.Alias("certprep"))
-            env.Depends("launcher", env.Alias("certprep"))
-    except Exception as e:
-        # Be conservative if alias lookup fails during early phases
-        print(f'Warning: Could not establish certprep ordering: {e}')
-
-    # Alias: certBuild (convenience umbrella alias)
-    # Use string targets/aliases so resolution happens after upstream defines them.
-    env.Alias("certBuild", [env.Alias("certprep"), "source", "user_docs", "dist", "launcher"])
 

--- a/jptools/setup_miscdeps_overlay.py
+++ b/jptools/setup_miscdeps_overlay.py
@@ -24,25 +24,8 @@ def main() -> int:
 
     # Copy all files under miscDepsJp/source as-is into repo source.
     # Any content policy (e.g. not placing espeak-data here) is enforced at repo level.
-    if not src.exists():
-        print(f"[ERROR] JP overlay source not found: {src}")
-        print("        Ensure miscDepsJp/source exists in this working tree.")
-        return 2
-    # Perform the copy
+
     overlay_copy(src, dst)
-    # Basic sanity check for common JP assets to catch partial/missing payloads early
-    # Only check for files expected to be provided by overlay payload.
-    # libopenjtalk.dll may be built/installed by separate jtalk build steps.
-    must_exist = [
-        dst / "synthDrivers" / "jtalk" / "libmecab.dll",
-    ]
-    missing = [str(p) for p in must_exist if not p.exists()]
-    if missing:
-        print("[ERROR] JP overlay completed but required files are missing:")
-        for m in missing:
-            print(f"        {m}")
-        print("        Verify miscDepsJp/source contains jtalk DLLs and try again.")
-        return 3
     return 0
 
 

--- a/readme-nvdajp.md
+++ b/readme-nvdajp.md
@@ -34,20 +34,6 @@ git config --global core.safecrlf warn
 ## リリース
 
 - 正式リリースはローカルマシンでコードサイニングして作成（CI は未署名の検証用ビルドのみ）
-- 証明書がローカル証明書ストアにある環境で以下を実行:
-
-```cmd
-set SCRIPT=jptools\certBuild2023.cmd
-set RELEASE=1
-set VERSION=2025.3.1jp
-set UPDATEVERSIONTYPE=nvdajpbeta
-set PUBLISHER=nvdajp
-powershell -ExecutionPolicy Bypass -NoProfile -File "ensureuv.ps1" run --directory "." %SCRIPT% version_build=9999 --all-cores
-call rununittests.bat
-call runsystemtests.bat --include NVDA --exclude restarts_on_crash
-call runsystemtests.bat --variable whichNVDA:installed --variable installDir:"output\nvda_%VERSION%.exe" --include installer
-call runsystemtests.bat --include chrome
-```
 
 ## ドキュメント
 
@@ -59,7 +45,6 @@ call runsystemtests.bat --include chrome
 詳細ドキュメント（旧版・参考）: `projectDocs/jp/legacy/readme-nvdajp-legacy.md`
 
 ## 関連 Issue
-
 - `#530`: 本家 2026.1 の日本語版へのマージ
 - `#539`: Step 1（3.11 x86 のままビルド基盤整合）
 


### PR DESCRIPTION
Revert #559/#558 to restore working JTalk (e2bea040 baseline). Verified overlay (jtalkCore.py, libopenjtalk.dll) present under source/synthDrivers/jtalk. Follow-ups will reintroduce changes incrementally with safeguards.