### PR TITLE
本家 2026.1 の日本語版へのマージ (alphajp-260106)

### DIFF
--- a/projectDocs/jp/changes-nvdajp.md
+++ b/projectDocs/jp/changes-nvdajp.md
@@ -443,6 +443,126 @@ def buildConfigH(target, source, env):
 
 - `projectDocs/jp/changes-nvdajp.md` - このドキュメント（2025.3jp と本家版の差分まとめ）
 
+#### 6.3 buildVersion.py の防御的プログラミング
+
+`source/buildVersion.py` に `version = version or "dev"` の行を追加しました。
+
+- **目的**: `version` 変数が `None` や空文字列になった場合に `"dev"` にフォールバックし、82行目の `version[0]` アクセスでのクラッシュを防ぐ
+- **背景**: 2025.3jp では存在していた独自のワークアラウンドで、2026.1 のマージ時に削除されていたものを追加
+- **実装**: `version_detailed` の設定後、`isTestVersion` の判定前に配置
+
+#### 6.4 点字テーブルのソート順の修正
+
+`source/brailleTables/__init__.py` の `listTables()` 関数で、`TableSource.BUILTIN_JP` をソートキーに含めるように修正しました。
+
+- **目的**: 日本語版の組み込み点字テーブル（`ja-jp-comp6.utb` など）が、他の組み込みテーブルと同様に優先順位でソートされるようにする
+- **背景**: 2025.3jp では `BUILTIN_JP` がソートキーに含まれていたが、2026.1 のマージ時に削除されていたものを追加
+- **実装**: `listTables()` 関数の `key` ラムダ関数で、`TableSource.BUILTIN_JP` を `TableSource.BUILTIN` と同様に扱うように修正
+
+#### 6.5 文字処理の拡張機能
+
+`source/characterProcessing.py` の `CharacterDescriptions` クラスに、JP固有の文字処理機能を追加しました。
+
+- **目的**: 日本語版の文字説明辞書（`characters.dic`）と文字読み方辞書のサポート、ユーザー定義辞書の読み込み、CLDR emoji の処理
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**:
+  - `CharacterDescriptions.__init__()` に以下を追加:
+    - `characters.dic` の読み込み処理（読み方情報 `_readings` の管理）
+    - CLDR emoji の処理（`symbolDictionaries` 設定で "cldr" が有効な場合）
+    - ユーザーの `characterDescriptions-{locale}.dic` の読み込み
+    - ユーザーの `characters-{locale}.dic` の読み込み
+  - `CharacterDescriptions.getCharacterReading()` メソッドを追加（文字の読み方を取得）
+  - グローバル関数 `getCharacterReading(locale, character)` を追加
+
+#### 6.6 設定デフォルト値の修正
+
+`source/config/configDefaults.py` の `DEFAULT_TEXT_PARAGRAPH_REGEX` で、CJK 句読点の正規表現に日本語の句点（「。」）を追加しました。
+
+- **目的**: 日本語の句点（「。」）を段落区切りの判定に含めることで、日本語テキストの段落読み上げを改善
+- **背景**: 2025.3jp では `cjk` 正規表現に「。」が含まれていたが、2026.1 のマージ時に削除されていたものを追加
+- **実装**: `cjk` 正規表現を `r"[．！？：；]"` から `r"[．。！？：；]"` に変更
+
+#### 6.7 コンテンツ認識の日本語文字処理
+
+`source/contentRecog/__init__.py` に、東アジア幅（East Asian Width）が狭い文字（Narrow）の処理を追加しました。
+
+- **目的**: OCR などのコンテンツ認識結果で、東アジア幅が狭い文字（半角文字など）の間に不要なスペースを挿入しないようにする
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**:
+  - `unicodedata.east_asian_width` のインポートを追加
+  - `isEastAsianNarrow(c)`、`startsWithEastAsianNarrow(s)`、`endsWithEastAsianNarrow(s)` 関数を追加
+  - `LinesWordsResult._parseData()` メソッドで、前の単語の末尾と次の単語の先頭がともに東アジア幅が狭い文字の場合、スペースを挿入しないように条件分岐を追加
+
+#### 6.8 編集可能テキストでの改行報告
+
+`source/editableText.py` の `script_caret_newLine()` メソッドに、改行時の報告機能を追加しました。
+
+- **目的**: 編集可能テキストで改行が発生した際に、「new line」と報告する機能を提供
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**:
+  - 改行が発生し、未確定の入力がなく、入力文字の読み上げが有効で、`jpAnnounceNewLine` 設定が有効な場合に「new line」と報告
+  - `queueHandler.queueFunction()` を使用して非同期に報告
+
+#### 6.9 イベントハンドラーでの ATOK UIComment の処理
+
+`source/eventHandler.py` の `shouldAcceptEvent()` 関数に、ATOK UIComment ウィンドウの `show` イベントを受け入れる処理を追加しました。
+
+- **目的**: ATOK（日本語入力システム）の UIComment ウィンドウの `show` イベントを受け入れることで、ATOK のコメント表示を適切に処理
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**: `eventName == "show"` の場合に、ウィンドウクラス名が "ATOK" で始まり "UIComment" で終わる場合に `True` を返すように条件分岐を追加
+
+#### 6.10 グローバルコマンドでの文字説明モードの処理
+
+`source/globalCommands.py` で、`speakSpelling` や `spellTextInfo` の呼び出しに `useCharacterDescriptions` と `useDetails` パラメータを追加しました。
+
+- **目的**: 文字説明モード（`characterDescriptionMode`）の状態に応じて、文字の説明や詳細情報を読み上げる機能を提供
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に一部の箇所で削除されていたものを追加
+- **実装**:
+  - `script_reportCurrentLine()`: `useDetails=characterDescriptionMode if scriptCount > 1 else False` を追加
+  - `script_reportCurrentSelection()`: `useDetails=scriptCount > 1` を追加
+  - `script_navigatorObject_current()`: `useCharacterDescriptions=characterDescriptionMode` と `useDetails=characterDescriptionMode` を追加
+  - `script_reportClipboardText()`: `useDetails=repeatCount > 1` を追加
+  - `script_showGui()`: `allowInSleepMode=True` を追加（スリープモードでも NVDA メニューを表示可能にする）
+
+#### 6.11 廃止された機能
+
+##### 6.11.1 MSHTA を使用したドキュメントファイルの表示
+
+`source/gui/__init__.py` の `run_hta()` 関数と、それを使用したドキュメントファイルの表示機能を廃止しました。
+
+- **背景**: 2025.3jp では `config.conf["language"]["openDocFileByMSHTA"]` 設定により、MSHTA（Microsoft HTML Application Host）を使用してドキュメントファイルを表示する機能が存在していました
+- **廃止理由**:
+  - MSHTA は Windows 11 で非推奨化されており、将来の Windows バージョンでは動作しない可能性が高い
+  - 標準的な `os.startfile()` で HTML ファイルは通常のブラウザで開けるため、特別な理由がない限り MSHTA は不要
+  - 本家版 2026.1 でも同様に削除されている
+- **影響**: ドキュメントファイルは従来通り `os.startfile()` で開かれます（通常はデフォルトブラウザで表示）
+
+#### 6.12 移植しないと判断した機能
+
+##### 6.12.1 inputCore.py での Enter キー処理時の Backspace キー状態取得
+
+`source/inputCore.py` の `executeGesture()` 関数で、Enter キー（`VK_RETURN`）が押された際に `getAsyncKeyState(VK_BACK)` を呼び出すコードが存在していましたが、移植しないと判断しました。
+
+- **背景**: 2025.3jp では存在していた機能で、Enter キー処理時に Backspace キーの状態を取得していた
+- **コード内容**:
+
+  ```python
+  if hasattr(gesture, "vkCode") and gesture.vkCode == winUser.VK_RETURN:
+      _ = winUser.getAsyncKeyState(winUser.VK_BACK)  # noqa: F841
+  ```
+
+- **移植しない理由**:
+  - 目的が不明確（戻り値を使用していない）
+  - 副作用を期待している可能性があるが、その意図が不明
+  - コメントがなく、実装の意図が推測できない
+  - 本家版 2026.1 でも削除されている
+  - 現在のコードベースでは `NVDAHelper.py` で IME のキャンセル状態をチェックする処理があるため、このワークアラウンドが現在も必要かどうか不明
+- **推測される副作用**:
+  - IME の確定処理のタイミング調整の可能性
+  - Windows のキー状態キャッシュの更新
+  - キーイベントの処理順序の調整
+- **今後の対応**: IME 関連の問題が再発した場合、目的を明確にしたコメントとともに再検討する
+
 ### 7. 「エラーを音で報告」機能の動作の違い
 
 #### 7.1 nvdajp での仕様変更

--- a/projectDocs/jp/changes-nvdajp.md
+++ b/projectDocs/jp/changes-nvdajp.md
@@ -4,6 +4,8 @@
 
 このドキュメントは、NVDA 日本語版 2025.3jp（`releasejp` ブランチ）と本家版 NVDA 2025.3（`nvaccess/nvda` の `rc` ブランチ）の**機能的な差分**をまとめたものです。
 
+2026.1jp に向けた日本語アルファ版に再移植された JP 固有コードについても説明します。
+
 **注意**: このドキュメントは、ユーザーや開発者が認識できる機能の追加・変更・削除に焦点を当てています。ビルドシステムの内部的な変更（サブツリー変換など）については、別のドキュメント（`projectDocs/jp/miscdepsjp-overlay-strategy.md` など）を参照してください。
 
 ### 比較対象
@@ -67,6 +69,15 @@
 
 - `source/brailleTables.py` (935行) - 点字テーブル処理の拡張
 
+##### 点字処理の JP 固有コード
+
+- `source/braille.py` - JP 固有の点字処理コードを実装
+  - `jpBrailleUtils` からのインポートと関数群（`useRawLabels()`, `_nvdajp()`, `getRoleLabel()` など）により、生ラベルと翻訳済みラベルの切り替えが可能
+  - `getPropertiesBraille()` 関数内で Composition の名前表示制御、EDITABLETEXT ロールの処理、テーブルヘッダー処理などの JP 固有処理を実装
+  - 他の関数（`_getAnnotationProperty()`, `getControlFieldBraille()`, `getFormatFieldBraille()`, `_addTextWithFields()`）でも JP 固有関数を使用
+  - `NVDAObjectRegion.update()` 内でテーブルヘッダー処理を実装
+  - `config.conf["braille"]["expandAtCursor"]` が `True` の場合、生ラベル（翻訳なし）を使用し、`False` の場合は翻訳済みラベルを使用します
+
 #### 1.3 日本語文字処理
 
 ##### 文字報告モード
@@ -112,6 +123,7 @@ NVDA日本語版は、文字単位の移動やレビューで、文字の説明�
 
 - `source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp_jp.py` (441行)
 - `source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp_jp_win10.py` (347行)
+- `source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py` - JP 固有の AppModule を条件付きでインポート。`nvdajpEnableKeyEvents` 設定が有効な場合のみ、Windows 11 以上では `_jp.py`、Windows 10 では `_jp_win10.py` をインポートします
 
 **注**: ファイル名は upstream の変更に追従して `windowsimmersiveshell` から `windowsinternal_composableshell` に変更されています。
 
@@ -207,6 +219,7 @@ ATOK の変換候補にコメントウィンドウがある場合の対応：
 #### 3.2 API とコマンドの拡張
 
 - `source/api.py` (26行変更) - API の拡張
+  - `setFocusObject()` 関数で、ATOK とブライル表示の組み合わせでの問題を回避するためのコードを実装。ブライル表示がない場合は上流の実装に合わせて `container` を使用し、ブライル表示がある場合は `parent` を直接設定します（関連チケット: ti33778, ti35974、nvaccess ticket 3873, 4145 を revert）
 - `source/globalCommands.py` (80行変更) - グローバルコマンドの拡張
 - `source/inputCore.py` (6行追加) - 入力コアの拡張
 - `source/eventHandler.py` (3行追加) - イベントハンドラーの拡張

--- a/projectDocs/jp/changes-nvdajp.md
+++ b/projectDocs/jp/changes-nvdajp.md
@@ -77,6 +77,7 @@
   - 他の関数（`_getAnnotationProperty()`, `getControlFieldBraille()`, `getFormatFieldBraille()`, `_addTextWithFields()`）でも JP 固有関数を使用
   - `NVDAObjectRegion.update()` 内でテーブルヘッダー処理を実装
   - `config.conf["braille"]["expandAtCursor"]` が `True` の場合、生ラベル（翻訳なし）を使用し、`False` の場合は翻訳済みラベルを使用します
+- `source/NVDAObjects/__init__.py` - `_get_roleTextBraille()` メソッドで、JP 固有の `getRoleLabel()` と `getLandmarkLabel()` 関数を使用してランドマークの点字ラベルを生成
 
 #### 1.3 日本語文字処理
 
@@ -132,6 +133,20 @@ NVDA日本語版は、文字単位の移動やレビューで、文字の説明�
 - **Esc キーでの未確定文字列クリア**: 日本語入力中に Esc キーが押されて未確定文字列がクリアされると、「クリア」と報告します（本家版では消去された文字列を報告）
 - **改行位置の不具合対策**: 日本語版で独自に行ったエディットコントロールの仕様変更の影響で、改行位置が正しく処理されないアプリ（Winbiff など）に対応するための設定項目を追加
 
+##### ANSI エディットボックスのワークアラウンド
+
+`source/NVDAObjects/window/edit.py` で、ANSI ビルドされたレガシーアプリケーションのエディットコントロールに対応するワークアラウンドを実装しています。
+
+- **目的**: ANSI アプリケーション（Shift-JIS エンコーディングを使用）で、エディットコントロールの行位置計算を正しく行う
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**: 
+  - `_needsWorkAroundEncoding()` メソッド: `jpAnsiEditbox` 設定が有効で、かつウィンドウが Unicode でない場合に `True` を返す
+  - `_startEndInBytesToStartEndInUnicodeChars()` メソッド: バイト位置を Unicode 文字位置に変換
+  - `_getLineOffsets()` メソッド内で、Unicode 文字位置をバイト位置に変換してから Windows API を呼び出し、結果を再び Unicode 文字位置に変換
+- **設定**: `config.conf["language"]["jpAnsiEditbox"]` で有効/無効を切り替え可能（デフォルト: `true`）
+- **既知の問題**: Winbiff などの一部のアプリケーションで改行位置が正しく処理されない場合がある。その場合は設定を無効にすることで回避可能
+- **注意**: レガシー機能のため、将来的に削除される可能性があります。現在の Windows ではほとんどのアプリが Unicode ビルドのため、通常は不要です
+
 ##### ATOK 候補コメント対応
 
 ATOK の変換候補にコメントウィンドウがある場合の対応：
@@ -139,6 +154,27 @@ ATOK の変換候補にコメントウィンドウがある場合の対応：
 - コメントウィンドウが表示されたらビープを鳴らし、ナビゲーターオブジェクトをコメントウィンドウに移動
 - コメントウィンドウの中央にマウスポインタを移動
 - コメントウィンドウの内容を読み上げ、コピー、確定などの操作が可能
+
+##### Microsoft IME 候補コメント対応
+
+`source/NVDAObjects/IAccessible/mscandui.py` で、Microsoft IME の変換候補にコメントがある場合の対応を実装しています。
+
+- **目的**: Microsoft IME の候補コメントを自動的に読み上げる
+- **実装**: 
+  - `MSCandUI40_candidateMenuItem.event_stateChange()` メソッドで、候補が選択された際に `announceSelectedCandidate` 設定が有効な場合、1秒後に `notifyCandidateComment()` 関数を呼び出す
+  - `notifyCandidateComment()` 関数で、`mscandui40.comment` クラス名のウィンドウを検索し、現在選択されている候補の識別読みと一致するコメントを読み上げる
+- **動作**: 候補が選択されてから1秒後に、該当する候補のコメントが自動的に読み上げられます
+
+##### 変換候補の識別読みの使用
+
+`source/NVDAObjects/behaviors.py` の `CandidateItem.getFormattedCandidateName()` メソッドで、`nvdajpEnableKeyEvents` 設定が有効な場合、変換候補の識別読み（区別読み）を使用して候補名を生成します。
+
+- **目的**: 同音異義語を区別するための識別読みを提供
+- **実装**: `jpUtils.getDiscriminantReading()` を使用して候補の識別読みを取得
+- **動作**: 
+  - ブライル表示がある場合は `forBraille=True` で識別読みを取得
+  - `announceCandidateNumber` 設定が有効な場合は「{番号} {識別読み}」の形式で返す
+  - 無効な場合は識別読みのみを返す
 
 ### 2. 設定とユーザーインターフェース
 
@@ -202,6 +238,15 @@ ATOK の変換候補にコメントウィンドウがある場合の対応：
 
 - 日本語などのマルチバイト文字を文字コードではなく文字として出力する変更
 
+##### 音声ビューアーの透明度設定
+
+`source/speechViewer.py` で、音声ビューアーウィンドウに透明度を設定する処理を追加しました。
+
+- **目的**: 音声ビューアーウィンドウを半透明にして、背景の内容が見えるようにする
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**: `__init__()` メソッドと `_createControls()` メソッドで `SetTransparent(229)` を呼び出し（90% の不透明度、`int(255.0 * 0.90)`）
+- **動作**: 音声ビューアーウィンドウが開かれた際に、自動的に90%の不透明度が設定されます
+
 ##### 寄付メニューの変更
 
 - 「寄付」メニューで開くサイトを NVDA 日本語版の寄付のご案内（https://www.nvda.jp/donate.html）に変更
@@ -249,6 +294,15 @@ WinAltair などのアプリケーションでスリープモードに切り替�
 - `nvdaController_setAppSleepMode` API によるアプリケーションスリープモード設定
 - スリープモードのアプリにおける IME の読み上げを抑止する設定オプション
 - スリープモードのアプリから NVDA+N で NVDA メニューが開く機能
+
+#### Excel のキーバインド拡張
+
+`source/NVDAObjects/window/excel.py` の `script_changeSelection()` メソッドに、Shift+Control+PageUp と Shift+Control+PageDown のキーバインドを追加しました。
+
+- **目的**: Excel のセル選択変更時に、Shift+Control+PageUp/Down キーでも操作できるようにする
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**: `script_changeSelection()` の `@script` デコレータの `gestures` リストに `"kb:shift+control+pageUp"` と `"kb:shift+control+pageDown"` を追加
+- **動作**: Control+PageUp/Down と同様に、ワークシート間の移動が可能になります
 
 ### 5. 開発ツール（開発者向け）
 
@@ -537,6 +591,17 @@ def buildConfigH(target, source, env):
   - 本家版 2026.1 でも同様に削除されている
 - **影響**: ドキュメントファイルは従来通り `os.startfile()` で開かれます（通常はデフォルトブラウザで表示）
 
+##### 6.11.2 UIA ModeTile と Input Flyout のワークアラウンド
+
+`source/NVDAObjects/UIA/__init__.py` の `findOverlayClasses()` メソッドで、`ModeTile` と `Input Flyout` のワークアラウンドを廃止しました。
+
+- **背景**: 2025.3jp では Windows 8 対応の試行錯誤として、`UIAClassName == "ModeTile"` と `UIAClassName == "Input Flyout"` の場合にそれぞれ `ModeTile` と `InputFlyout` クラスを追加するワークアラウンドが存在していました
+- **廃止理由**:
+  - Windows 8 は既にサポート終了しており、現在の Windows バージョンでは不要
+  - 本家版 2026.1 でも同様に削除されている
+  - レガシーなワークアラウンドを維持する必要がない
+- **影響**: Windows 8 環境での動作に影響する可能性がありますが、現在サポート対象外のため問題ありません
+
 #### 6.12 移植しないと判断した機能
 
 ##### 6.12.1 inputCore.py での Enter キー処理時の Backspace キー状態取得
@@ -562,6 +627,55 @@ def buildConfigH(target, source, env):
   - Windows のキー状態キャッシュの更新
   - キーイベントの処理順序の調整
 - **今後の対応**: IME 関連の問題が再発した場合、目的を明確にしたコメントとともに再検討する
+
+##### 6.12.2 logHandler.py での Unicode エスケープシーケンス処理
+
+`source/logHandler.py` の `Logger._log()` メソッドで、ログメッセージ内の `\uXXXX` 形式の Unicode エスケープシーケンスを実際の文字に変換する処理が存在していましたが、移植しないと判断しました。
+
+- **背景**: 2025.3jp では存在していた機能で、ログメッセージ内の `\uXXXX` 形式のエスケープシーケンスを実際の Unicode 文字に変換していた
+- **コード内容**:
+  ```python
+  from six import unichr, text_type
+  import re
+  try:
+      msg = re.sub(r"\\u([0-9a-f]{4})", lambda x: unichr(int("0x" + x.group(1), 16)), text_type(msg))
+  except:  # noqa: E722
+      pass
+  ```
+- **移植しない理由**:
+  - Python 3 では文字列は既に Unicode なので、通常はこの処理は不要
+  - `six` モジュールへの依存を避けられる（Python 3.13 では `text_type` は `str`、`unichr` は `chr` と同じ）
+  - 本家版 2026.1 でも削除されている
+  - 日本語環境でこの処理が必要だった明確な記録が見つからない
+- **今後の対応**: 外部ライブラリやエラーメッセージで `\uXXXX` 形式のエスケープシーケンスが問題になる場合は、`six` を使わない形で再検討する
+
+##### 6.12.3 mathPlayer.py での常に英語で数式を読み上げる設定
+
+`source/mathPres/mathPlayer.py` の `_setSpeechLanguage()` メソッドで、`config.conf["language"]["alwaysSpeakMathInEnglish"]` 設定により常に英語で数式を読み上げる機能が存在していましたが、移植しないと判断しました。
+
+- **背景**: 2025.3jp では存在していた機能で、設定により数式を常に英語で読み上げることができた
+- **コード内容**:
+  ```python
+  if config.conf["language"]["alwaysSpeakMathInEnglish"]:
+      lang = "en"
+  ```
+- **移植しない理由**:
+  - MathPlayer はレガシーな数式読み上げエンジンであり、現在は MathCAT が推奨されている
+  - 本家版 2026.1 でも削除されている
+  - MathCAT では同様の機能が提供されている可能性がある
+- **今後の対応**: MathCAT で同様の機能が必要な場合は、MathCAT 側で実装を検討する
+
+#### 6.13 キーラベルの追加
+
+`source/keyLabels.py` に、JP固有のキーラベルを追加しました。
+
+- **目的**: IME（日本語入力システム）関連のキーと、Pause キーのラベルを提供
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**: 以下のキーラベルを追加:
+  - `"imenonconvert"`: "IME non convert"（無変換キー）
+  - `"imeconvert"`: "IME convert"（変換キー）
+  - `"imechangestatus1"`, `"imechangestatus2"`, `"imechangestatus3"`: "toggle input method"（IME 切り替えキー）
+  - `"pause"`: "pause"（Pause キー）
 
 ### 7. 「エラーを音で報告」機能の動作の違い
 

--- a/projectDocs/jp/changes-nvdajp.md
+++ b/projectDocs/jp/changes-nvdajp.md
@@ -19,6 +19,41 @@
 
 #### 1.1 音声合成（シンセサイザー）
 
+##### デフォルトシンセサイザーの優先順位
+
+`source/synthDriverHandler.py` で、デフォルトシンセサイザーの優先順位を日本語版向けに変更しました。
+
+- **目的**: 日本語環境では JTalk シンセサイザーを優先的に使用する
+- **実装**: `defaultSynthPriorityList` を `["oneCore", "nvdajp_jtalk", "silence"]` に設定
+- **動作**: 新規インストール時や設定が "auto" の場合、最初に `oneCore`、次に `nvdajp_jtalk`、最後に `silence` の順で初期化を試みます
+
+##### OneCore シンセサイザーの isSpeaking() メソッド
+
+`source/synthDrivers/oneCore.py` で、OneCore シンセサイザーに `isSpeaking()` メソッドを追加しました。
+
+- **目的**: シンセサイザーが現在読み上げ中かどうかを確認する機能を提供
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**: 
+  - `__init__()` メソッドで `self._isSpeaking = False` を初期化
+  - `speak()` メソッドで `self._isSpeaking = True` を設定
+  - `_processQueue()` メソッドで、読み上げが完了した際に `self._isSpeaking = False` を設定
+  - `isSpeaking()` メソッドで `self._isSpeaking` の値を返す
+- **動作**: シンセサイザーが読み上げ中かどうかを `isSpeaking()` メソッドで確認できます
+
+##### SAPI4 シンセサイザーの拡張機能
+
+`source/synthDrivers/sapi4.py` で、SAPI4 シンセサイザーに複数の拡張機能を追加しました。
+
+- **目的**: SAPI4 シンセサイザーの動作を改善し、互換性を向上させる
+- **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
+- **実装**:
+  - **`isSpeaking()` と `setSpeaking()` メソッド**: シンセサイザーが読み上げ中かどうかを追跡。`SynthDriverBufSink.ITTSBufNotifySink_TextDataDone()` で読み上げ完了時に自動的に `False` に設定
+  - **`lastIndex` のクリア**: `cancel()` メソッドで `self.lastIndex = None` を設定して、キャンセル時にインデックスをクリア
+  - **`_rate` キャッシュ**: `_get_rate()` と `_set_rate()` で速度設定をキャッシュし、API 呼び出しを削減。また、`_get_rate()` の戻り値を最大 100% に制限
+  - **Bullet 文字の削除**: `speak()` メソッドで、一部の SAPI4 音声で問題を引き起こす bullet 文字（`\u2022` と `\uf0b7`）を削除
+  - **`CharacterModeCommand` の無効化**: `elif False and isinstance(item, CharacterModeCommand):` により、文字モードコマンドの処理を無効化（互換性の問題を回避）
+- **動作**: これらの拡張により、SAPI4 シンセサイザーの動作がより安定し、互換性が向上します
+
 ##### JTalk シンセサイザードライバー
 
 - `miscDepsJp/source/synthDrivers/jtalk/` - 日本語音声合成ドライバー

--- a/source/NVDAObjects/IAccessible/mscandui.py
+++ b/source/NVDAObjects/IAccessible/mscandui.py
@@ -78,6 +78,53 @@ class MSCandUI_candidateListItem(BaseCandidateItem):
 	def event_stateChange(self):
 		if controlTypes.State.SELECTED in self.states:
 			reportSelectedCandidate(self)
+			# BEGIN JP PATCH
+			# nvdajp: notify candidate comment for Microsoft IME
+			if not config.conf["inputComposition"]["announceSelectedCandidate"]:
+				return
+			import wx
+
+			wx.CallLater(1000, notifyCandidateComment, self)
+			# END JP PATCH
+
+
+def notifyCandidateComment(item):
+	# BEGIN JP PATCH
+	# nvdajp: function to notify Microsoft IME candidate comment
+	import windowUtils
+	import NVDAObjects.IAccessible
+	import winUser
+	import jpUtils
+
+	parent = api.getDesktopObject().windowHandle
+	try:
+		obj = NVDAObjects.IAccessible.getNVDAObjectFromEvent(
+			windowUtils.findDescendantWindow(parent, className="mscandui40.comment", visible=True),
+			winUser.OBJID_CLIENT,
+			0,
+		)
+	except LookupError:
+		return
+	if not obj or not obj.firstChild or not obj.firstChild.children:
+		return
+	currDiscReading = item.name
+	msg = ""
+	isCurrItem = False
+	for o in obj.firstChild.children:
+		s = o.name
+		d = o.decodedAccDescription
+		if d == "Headword":
+			if currDiscReading == jpUtils.getDiscriminantReading(s):
+				isCurrItem = True
+			else:
+				isCurrItem = False
+		if d:
+			s = None
+		if s and isCurrItem:
+			msg += s
+	if msg:
+		ui.message(msg)
+	# END JP PATCH
 
 
 class MSCandUI21_candidateMenuItem(BaseCandidateItem):

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -514,8 +514,11 @@ class NVDAObject(
 		which will override the standard label for this object's role property as well as the value of roleText.
 		By default, NVDA falls back to using roleText.
 		"""
-		if self.landmark and self.landmark in braille.landmarkLabels:
-			return f"{braille.roleLabels[controlTypes.Role.LANDMARK]} {braille.landmarkLabels[self.landmark]}"
+		# BEGIN JP PATCH
+		# nvdajp: use getRoleLabel and getLandmarkLabel functions for JP-specific braille processing
+		if self.landmark and self.landmark in braille.getLandmarkLabels():
+			return f"{braille.getRoleLabel(controlTypes.Role.LANDMARK)} {braille.getLandmarkLabel(self.landmark)}"
+		# END JP PATCH
 		return self.roleText
 
 	#: Typing information for auto property _get_value

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -635,6 +635,18 @@ class KeyboardHandlerBasedTypedCharSupport(EnhancedTermTypedCharSupport):
 
 class CandidateItem(NVDAObject):
 	def getFormattedCandidateName(self, number, candidate):
+		# BEGIN JP PATCH
+		# nvdajp: use discriminant reading for candidate names when nvdajpEnableKeyEvents is enabled
+		import jpUtils
+
+		if config.conf["keyboard"]["nvdajpEnableKeyEvents"]:
+			fb = braille.handler.displaySize > 0
+			c = jpUtils.getDiscriminantReading(candidate, forBraille=fb)
+			log.debug("{number} {candidate} {c}".format(number=number, candidate=candidate, c=c))
+			if config.conf["language"]["announceCandidateNumber"]:
+				return _("{number} {candidate}").format(number=number, candidate=c)
+			return c
+		# END JP PATCH
 		if config.conf["inputComposition"]["alwaysIncludeShortCharacterDescriptionInCandidateName"]:
 			describedSymbols = []
 			for symbol in candidate:

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -618,11 +618,58 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 		else:
 			return watchdog.cancellableSendMessage(self.obj.windowHandle, winUser.EM_LINEFROMCHAR, offset, 0)
 
+	# BEGIN JP PATCH
+	# nvdajp: workaround for ANSI edit controls (legacy applications)
+	def _needsWorkAroundEncoding(self):
+		"""Check if ANSI encoding workaround is needed for this edit control.
+		This is for legacy ANSI applications that use Shift-JIS encoding.
+		"""
+		return config.conf["language"]["jpAnsiEditbox"] and (not self.obj.isWindowUnicode)
+
+	def _startEndInBytesToStartEndInUnicodeChars(self, start, end):
+		"""Convert byte positions to Unicode character positions for ANSI edit controls.
+		This is needed because ANSI edit controls work with byte positions,
+		but NVDA works with Unicode character positions.
+		"""
+		# start/end in bytes to start/end in unicode chars
+		story_text = self._getStoryText()
+		start_new = end_new = -1
+		bytepos = 0
+		for charpos, ch in enumerate(story_text):
+			cb = len(ch.encode("mbcs", "replace"))
+			if bytepos == start:
+				start_new = charpos
+			if bytepos == end:
+				end_new = charpos
+				break
+			bytepos += cb
+		if end_new == -1:
+			end_new = len(story_text)
+		return (start_new, end_new)
+	# END JP PATCH
+
 	def _getLineOffsets(self, offset):
+		# BEGIN JP PATCH
+		# nvdajp: workaround for ANSI edit controls
+		if self._needsWorkAroundEncoding():
+			# offset in unicode chars to offset in bytes
+			s = self._getStoryText()[0:offset]
+			offset = len(s.encode("mbcs", "replace"))
+		# END JP PATCH
 		lineNum = self._getLineNumFromOffset(offset)
 		start = watchdog.cancellableSendMessage(self.obj.windowHandle, winUser.EM_LINEINDEX, lineNum, 0)
 		length = watchdog.cancellableSendMessage(self.obj.windowHandle, winUser.EM_LINELENGTH, offset, 0)
 		end = start + length
+		# BEGIN JP PATCH
+		# nvdajp: convert byte positions back to Unicode character positions
+		if self._needsWorkAroundEncoding():
+			start_new, end_new = self._startEndInBytesToStartEndInUnicodeChars(start, end)
+			log.debug(
+				"offset %d lineNum %d start %d length %d end %d start_new %d end_new %d"
+				% (offset, lineNum, start, length, end, start_new, end_new)
+			)
+			return (start_new, end_new)
+		# END JP PATCH
 		# If we just seem to get invalid line info, calculate manually
 		if (
 			start <= 0

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1181,6 +1181,11 @@ class ExcelWorksheet(ExcelBase):
 			"kb:control+shift+8",
 			"kb:control+pageUp",
 			"kb:control+pageDown",
+			# BEGIN JP PATCH
+			# nvdajp: restore Shift+Control+PageUp/Down key bindings for Excel cell navigation
+			"kb:shift+control+pageUp",
+			"kb:shift+control+pageDown",
+			# END JP PATCH
 			"kb:control+a",
 			"kb:control+v",
 			"kb:shift+f11",

--- a/source/api.py
+++ b/source/api.py
@@ -130,7 +130,16 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 				origAncestors = oldFocusLine[0 : index + 1]
 				# make sure to cache the last old ancestor as a parent on the first new ancestor so as not to leave a broken parent cache
 				if ancestors and origAncestors:
-					ancestors[0].container = origAncestors[-1]
+					# BEGIN JP PATCH
+					# nvdajp ti33778 ti35974
+					# work around ATOK and braille display
+					# reverting nvaccess ticket 3873 4145
+					if braille.handler.display.name == "noBraille":
+						# merged nvaccess master
+						ancestors[0].container = origAncestors[-1]
+					else:
+						ancestors[0].parent = origAncestors[-1]
+					# END JP PATCH
 				origAncestors.extend(ancestors)
 				ancestors = origAncestors
 				focusDifferenceLevel = index + 1

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -447,3 +447,12 @@ class AppModule(appModuleHandler.AppModule):
 			controlTypes.Role.LIST,  # Clipboard history item actions list
 		):
 			obj._shouldAllowUIALiveRegionChangeEvent = False
+
+
+# BEGIN JP PATCH
+if config.conf["keyboard"]["nvdajpEnableKeyEvents"]:
+	if winVersion.getWinVer() >= winVersion.WIN11:
+		from .windowsinternal_composableshell_experiences_textinput_inputapp_jp import AppModule  # noqa: F401
+	else:
+		from .windowsinternal_composableshell_experiences_textinput_inputapp_jp_win10 import AppModule  # noqa: F401
+# END JP PATCH

--- a/source/braille.py
+++ b/source/braille.py
@@ -313,6 +313,63 @@ landmarkLabels = {
 	"form": pgettext("braille landmark abbreviation", "form"),
 }
 
+# BEGIN JP PATCH
+from jpBrailleUtils import (  # noqa: E402
+	roleLabels as rawRoleLabels,
+	positiveStateLabels as rawPositiveStateLabels,
+	negativeStateLabels as rawNegativeStateLabels,
+	landmarkLabels as rawLandmarkLabels,
+)
+
+
+def useRawLabels() -> bool:
+	return config.conf["braille"]["expandAtCursor"]
+
+
+def _nvdajp(rawLabel: str) -> str:
+	if useRawLabels():
+		return rawLabel
+	return _(rawLabel)
+
+
+def getRoleLabel(role: controlTypes.Role, displayString: Optional[str] = None) -> str:
+	if useRawLabels():
+		return rawRoleLabels.get(role, displayString)
+	return roleLabels.get(role, displayString)
+
+
+def getPositiveStateLabel(state: controlTypes.State) -> str:
+	if useRawLabels():
+		return rawPositiveStateLabels.get(state)
+	return positiveStateLabels.get(state)
+
+
+def getPositiveStateLabels() -> typing.Dict[controlTypes.State, str]:
+	if useRawLabels():
+		return rawPositiveStateLabels
+	return positiveStateLabels
+
+
+def getNegativeStateLabels() -> typing.Dict[controlTypes.State, str]:
+	if useRawLabels():
+		return rawNegativeStateLabels
+	return negativeStateLabels
+
+
+def getLandmarkLabel(name: str) -> str:
+	if useRawLabels():
+		return rawLandmarkLabels.get(name)
+	return landmarkLabels.get(name)
+
+
+def getLandmarkLabels() -> typing.Dict[str, str]:
+	if useRawLabels():
+		return rawLandmarkLabels
+	return landmarkLabels
+
+
+# END JP PATCH
+
 #: Cursor shapes
 CURSOR_SHAPES = (
 	# Translators: The description of a braille cursor shape.
@@ -667,7 +724,9 @@ def _getAnnotationProperty(
 		hasDetailsRoleTemplate = _("has %s")
 		rolesLabels = list(
 			(
-				hasDetailsRoleTemplate % roleLabels.get(role, role.displayString)
+				# BEGIN JP PATCH
+				hasDetailsRoleTemplate % getRoleLabel(role, role.displayString)
+				# END JP PATCH
 				for role in detailsRoles
 				if role  # handle None case without the "has X" grammar.
 			)
@@ -683,8 +742,18 @@ def _getAnnotationProperty(
 def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 	textList = []
 	name = propertyValues.get("name")
-	if name:
-		textList.append(name)
+	# BEGIN JP PATCH
+	# if name:
+	# textList.append(name)
+	isComposition = True
+	if config.conf["keyboard"]["nvdajpEnableKeyEvents"]:
+		if name and name != _("Composition"):
+			isComposition = False
+			textList.append(name)
+	else:
+		if name:
+			textList.append(name)
+	# END JP PATCH
 	role: Optional[Union[controlTypes.Role, int]] = propertyValues.get("role")
 	roleText = propertyValues.get("roleText")
 	states = propertyValues.get("states")
@@ -704,13 +773,17 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 		if role == controlTypes.Role.HEADING and level:
 			# Translators: Displayed in braille for a heading with a level.
 			# %s is replaced with the level.
-			roleText = _("h%s") % level
+			# BEGIN JP PATCH
+			roleText = _nvdajp("h%s") % level
+			# END JP PATCH
 			level = None
 		elif role == controlTypes.Role.LINK and states and controlTypes.State.VISITED in states:
 			states = states.copy()
 			states.discard(controlTypes.State.VISITED)
 			# Translators: Displayed in braille for a link which has been visited.
-			roleText = _("vlnk")
+			# BEGIN JP PATCH
+			roleText = _nvdajp("vlnk")
+			# END JP PATCH
 		elif (
 			role == controlTypes.Role.LIST
 			and states
@@ -729,9 +802,19 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 		) and role in controlTypes.silentRolesOnFocus:
 			roleText = None
 		else:
-			roleText = roleLabels.get(role, role.displayString)
+			# BEGIN JP PATCH
+			roleText = getRoleLabel(role, role.displayString)
+			# END JP PATCH
 	elif role is None:
 		role = propertyValues.get("_role")
+	# BEGIN JP PATCH
+	if (
+		config.conf["keyboard"]["nvdajpEnableKeyEvents"]
+		and isComposition
+		and role == controlTypes.Role.EDITABLETEXT
+	):
+		roleText = None
+	# END JP PATCH
 	value = propertyValues.get("value")
 	if value and role not in controlTypes.silentValuesForRoles:
 		textList.append(value)
@@ -743,8 +826,10 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 				controlTypes.OutputReason.FOCUS,
 				states,
 				None,
-				positiveStateLabels,
-				negativeStateLabels,
+				# BEGIN JP PATCH
+				getPositiveStateLabels(),
+				getNegativeStateLabels(),
+				# END JP PATCH
 			),
 		)
 	if roleText:
@@ -775,6 +860,14 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 			# Translators: Displayed in braille when an object (e.g. a tree view item) has a hierarchical level.
 			# %s is replaced with the level.
 			textList.append(_("lv %s") % positionInfo["level"])
+	# BEGIN JP PATCH https://github.com/nvdajp/nvdajp/issues/109
+	rowHeaderText = propertyValues.get("rowHeaderText")
+	if rowHeaderText:
+		textList.append(rowHeaderText)
+	columnHeaderText = propertyValues.get("columnHeaderText")
+	if columnHeaderText:
+		textList.append(columnHeaderText)
+	# END JP PATCH
 	if rowNumber:
 		if includeTableCellCoords and not cellCoordsText:
 			if rowSpan > 1:
@@ -790,9 +883,11 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 				rowStr = _("r{rowNumber}").format(rowNumber=rowNumber)
 			textList.append(rowStr)
 	if columnNumber:
-		columnHeaderText = propertyValues.get("columnHeaderText")
-		if columnHeaderText:
-			textList.append(columnHeaderText)
+		# BEGIN JP PATCH (moved to above) https://github.com/nvdajp/nvdajp/issues/109
+		# columnHeaderText = propertyValues.get("columnHeaderText")
+		# if columnHeaderText:
+		# textList.append(columnHeaderText)
+		# END JP PATCH
 		if includeTableCellCoords and not cellCoordsText:
 			if columnSpan > 1:
 				# Translators: Displayed in braille for the table cell column numbers when a cell spans multiple columns.
@@ -864,6 +959,20 @@ class NVDAObjectRegion(Region):
 		)
 		description = obj.description if _shouldUseDescription else None
 		detailsRoles = obj.annotations.roles if obj.annotations else None
+		# BEGIN JP PATCH
+		columnHeaderText = None
+		try:
+			if hasattr(obj, "columnHeaderText") and config.conf["documentFormatting"]["reportTableHeaders"]:
+				columnHeaderText = obj.columnHeaderText
+		except NotImplementedError:
+			pass
+		rowHeaderText = None
+		try:
+			if hasattr(obj, "rowHeaderText") and config.conf["documentFormatting"]["reportTableHeaders"]:
+				rowHeaderText = obj.rowHeaderText
+		except NotImplementedError:
+			pass
+		# END JP PATCH
 		text = getPropertiesBraille(
 			name=name,
 			role=role,
@@ -880,6 +989,10 @@ class NVDAObjectRegion(Region):
 			cellCoordsText=obj.cellCoordsText
 			if config.conf["documentFormatting"]["reportTableCellCoords"]
 			else None,
+			# BEGIN JP PATCH
+			columnHeaderText=columnHeaderText,
+			rowHeaderText=rowHeaderText,
+			# END JP PATCH
 			errorMessage=errorMessage,
 		)
 		if role == controlTypes.Role.MATH:
@@ -972,7 +1085,9 @@ def getControlFieldBraille(
 	roleText = field.get("roleTextBraille", field.get("roleText"))
 	landmark = field.get("landmark")
 	if not roleText and role == controlTypes.Role.LANDMARK and landmark:
-		roleText = f"{roleLabels[controlTypes.Role.LANDMARK]} {landmarkLabels[landmark]}"
+		# BEGIN JP PATCH
+		roleText = f"{getRoleLabel(controlTypes.Role.LANDMARK)} {getLandmarkLabel(landmark)}"
+		# END JP PATCH
 
 	content = field.get("content")
 
@@ -1185,7 +1300,9 @@ def getFormatFieldBraille(field, fieldCache, isAtStart, formatConfig):
 		link = field.get("link")
 		oldLink = fieldCache.get("link")
 		if link and link != oldLink:
-			textList.append(roleLabels[controlTypes.Role.LINK])
+			# BEGIN JP PATCH
+			textList.append(getRoleLabel(controlTypes.Role.LINK))
+			# END JP PATCH
 	if formatConfig["reportComments"]:
 		comment = field.get("comment")
 		oldComment = fieldCache.get("comment") if fieldCache is not None else None
@@ -1430,7 +1547,9 @@ class TextInfoRegion(Region):
 									formatConfig,
 								)
 								if not presCat or presCat is field.PRESCAT_LAYOUT:
-									textList.append(positiveStateLabels[controlTypes.State.CLICKABLE])
+									# BEGIN JP PATCH
+									textList.append(getPositiveStateLabel(controlTypes.State.CLICKABLE))
+									# END JP PATCH
 								inClickable = True
 						text = info.getControlFieldBraille(field, ctrlFields, True, formatConfig)
 						if text:

--- a/source/brailleTables/__init__.py
+++ b/source/brailleTables/__init__.py
@@ -171,7 +171,12 @@ def listTables() -> list[BrailleTable]:
 	"""
 	return sorted(
 		_tables.values(),
-		key=lambda table: (table.source != TableSource.BUILTIN, strxfrm(table.displayName)),
+		# BEGIN JP PATCH
+		key=lambda table: (
+			table.source not in (TableSource.BUILTIN, TableSource.BUILTIN_JP),
+			strxfrm(table.displayName),
+		),
+		# END JP PATCH
 	)
 
 

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -79,4 +79,6 @@ except ImportError:
 
 version_detailed = formatBuildVersionString()
 # A test version is anything other than a final or rc release.
+# nvdajp: defensive programming to ensure version is never None or empty
+version = version or "dev"
 isTestVersion = not version[0].isdigit() or "alpha" in version or "beta" in version or "dev" in version

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -122,11 +122,107 @@ class CharacterDescriptions(object):
 		log.debug("Loaded %d entries." % len(self._entries))
 		f.close()
 
+		# BEGIN JP PATCH
+		# nvdajp characters.dic
+		self._readings = {}
+		fileName = os.path.join(globalVars.appDir, "locale", locale, "characters.dic")
+		if os.path.isfile(fileName):
+			f = codecs.open(fileName, "r", "utf_8_sig", errors="replace")
+			for line in f:
+				if line.isspace() or line.startswith("#"):
+					continue
+				line = line.rstrip("\r\n")
+				temp = line.split("\t")
+				if len(temp) > 1:
+					key = temp.pop(0)
+					code = temp.pop(0)
+					rd = temp.pop(0)
+					if rd.startswith("[") and rd.endswith("]"):
+						self._readings[key] = rd[1:-1]
+					self._entries[key] = temp
+				else:
+					log.warning("can't parse line '%s'" % line)
+			log.debug("Loaded %d readings." % len(self._readings))
+			f.close()
+		# nvdajp characters.dic end
+
+		# nvdajp cldr emoji
+		if "cldr" in config.conf["speech"]["symbolDictionaries"]:  # type: ignore
+			fileName = os.path.join(globalVars.appDir, "locale", locale, "cldr.dic")
+			if os.path.isfile(fileName):
+				import unicodedata
+
+				f = codecs.open(fileName, "r", "utf_8_sig", errors="replace")
+				for line in f:
+					line = line.rstrip("\r\n")
+					temp = line.split("\t")
+					if len(temp) > 1:
+						key = temp.pop(0)
+						if unicodedata.category(key[0]) not in ("So", "Cn"):
+							continue
+						rd = temp.pop(0)
+						self._readings[key] = rd
+						self._entries[key] = (rd,)
+				f.close()
+		# nvdajp cldr emoji end
+
+		# nvdajp users chardesc
+		fileName = os.path.join(globalVars.appArgs.configPath, "characterDescriptions-%s.dic" % locale)
+		if os.path.isfile(fileName):
+			log.debug("Loading users characterDescriptions-%s.dic" % locale)
+			f = codecs.open(fileName, "r", "utf_8_sig", errors="replace")
+			for line in f:
+				if line.isspace() or line.startswith("#"):
+					continue
+				line = line.rstrip("\r\n")
+				temp = line.split("\t")
+				if len(temp) > 1:
+					key = temp.pop(0)
+					self._entries[key] = temp
+				else:
+					log.warning("can't parse line '%s'" % line)
+			log.debug("Loaded users characterDescriptions.")
+			f.close()
+		# nvdajp users chardesc end
+
+		# nvdajp users characters
+		fileName = os.path.join(globalVars.appArgs.configPath, "characters-%s.dic" % locale)
+		if os.path.isfile(fileName):
+			f = codecs.open(fileName, "r", "utf_8_sig", errors="replace")
+			for line in f:
+				if line.isspace() or line.startswith("#"):
+					continue
+				line = line.rstrip("\r\n")
+				temp = line.split("\t")
+				if len(temp) > 1:
+					key = temp.pop(0)
+					code = temp.pop(0)  # noqa: F841
+					rd = temp.pop(0)
+					if rd.startswith("[") and rd.endswith("]"):
+						self._readings[key] = rd[1:-1]
+					self._entries[key] = temp
+				else:
+					log.warning("can't parse line '%s'" % line)
+			log.debug("Loaded users characters.")
+			f.close()
+		# nvdajp users characters end
+		# END JP PATCH
+
 	def getCharacterDescription(self, character: str) -> Optional[List[str]]:
 		"""
 		Looks up the given character and returns a list containing all the description strings found.
 		"""
 		return self._entries.get(character)
+
+	# BEGIN JP PATCH
+	# nvdajp reading
+	def getCharacterReading(self, character):
+		if character in self._readings:
+			return self._readings.get(character)
+		return character
+
+	# nvdajp reading end
+	# END JP PATCH
 
 
 _charDescLocaleDataMap: LocaleDataMap[CharacterDescriptions] = LocaleDataMap(CharacterDescriptions)
@@ -149,6 +245,20 @@ def getCharacterDescription(locale: str, character: str) -> Optional[List[str]]:
 	if not desc and not locale.startswith("en"):
 		desc = getCharacterDescription("en", character)
 	return desc
+
+
+# BEGIN JP PATCH
+# nvdajp
+def getCharacterReading(locale, character):
+	try:
+		l = _charDescLocaleDataMap.fetchLocaleData(locale)  # noqa: E741
+	except LookupError:
+		return character
+	return l.getCharacterReading(character)
+
+
+# nvdajp end
+# END JP PATCH
 
 
 # Speech symbol levels

--- a/source/config/configDefaults.py
+++ b/source/config/configDefaults.py
@@ -27,5 +27,8 @@ DEFAULT_TEXT_PARAGRAPH_REGEX = r"({lookBehind}{optQuote}{punc}{optQuote}{optWiki
 	# since they don't trigger as many false positives.
 	punc2=r"[?!]",
 	# We also check for CJK full-width punctuation marks without any extra rules.
-	cjk=r"[．！？：；]",
+	# BEGIN JP PATCH
+	# nvdajp: include Japanese period (。) in CJK punctuation marks
+	cjk=r"[．。！？：；]",
+	# END JP PATCH
 )

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -21,9 +21,30 @@ import cursorManager
 import textInfos.offsets
 from abc import ABCMeta, abstractmethod
 from locationHelper import RectLTWH
+# BEGIN JP PATCH
+# nvdajp: import for East Asian width checking
+from unicodedata import east_asian_width
+# END JP PATCH
 from NVDAObjects import NVDAObject
 
 onRecognizeResultCallbackT = Callable[[Union["RecognitionResult", Exception]], None]
+
+# BEGIN JP PATCH
+# nvdajp: functions for checking East Asian narrow characters
+def isEastAsianNarrow(c):
+	return c and (east_asian_width(str(c)) == "Na")
+
+
+def startsWithEastAsianNarrow(s):
+	return s and isEastAsianNarrow(s[0])
+
+
+def endsWithEastAsianNarrow(s):
+	return s and isEastAsianNarrow(s[-1])
+
+
+# nvdajp end
+# END JP PATCH
 
 
 class BaseContentRecogTextInfo(cursorManager._ReviewCursorManagerTextInfo):
@@ -236,6 +257,16 @@ class LinesWordsResult(RecognitionResult):
 			for word in line:
 				if firstWordOfLine:
 					firstWordOfLine = False
+				# BEGIN JP PATCH
+				# nvdajp: don't add space between East Asian narrow characters
+				elif (
+					self._textList
+					and endsWithEastAsianNarrow(self._textList[-1])
+					and startsWithEastAsianNarrow(word["text"])
+				):
+					# Don't separate with a space for East Asian narrow characters.
+					pass
+				# END JP PATCH
 				else:
 					# Separate with a space.
 					self._textList.append(" ")

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -214,6 +214,22 @@ class EditableText(TextContainerObject, ScriptableObject):
 		bookmark = info.bookmark
 		gesture.send()
 		caretMoved, newInfo = self._hasCaretMoved(bookmark)
+		# BEGIN JP PATCH
+		# nvdajp: announce new line
+		from NVDAHelper import lastCompAttr
+
+		if (
+			caretMoved
+			and (not lastCompAttr)
+			and config.conf["keyboard"]["speakTypedCharacters"]
+			and config.conf["language"]["jpAnnounceNewLine"]
+		):
+			import queueHandler
+			from gui import _
+
+			# Translators: new line of editable text
+			queueHandler.queueFunction(queueHandler.eventQueue, speech.speakMessage, _("new line"))
+		# END JP PATCH
 		if not caretMoved or not newInfo:
 			return
 		# newInfo.copy should be good enough here, but in MS Word we get strange results.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -501,6 +501,11 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 	if eventName == "hide":
 		return False
 	if eventName == "show":
+		# BEGIN JP PATCH
+		# nvdajp: ATOKxxUIComment
+		if wClass.startswith("ATOK") and wClass.endswith("UIComment"):
+			return True
+		# END JP PATCH
 		# Only accept 'show' events for specific cases, as otherwise we get flooded.
 		return wClass in (
 			"Frame Notification Bar",  # notification bars

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -281,7 +281,13 @@ class GlobalCommands(ScriptableObject):
 		if scriptCount == 0:
 			speech.speakTextInfo(info, unit=textInfos.UNIT_LINE, reason=controlTypes.OutputReason.CARET)
 		else:
-			speech.spellTextInfo(info, useCharacterDescriptions=scriptCount > 1)
+			# BEGIN JP PATCH (character description mode)
+			speech.spellTextInfo(
+				info,
+				useCharacterDescriptions=scriptCount > 1,
+				useDetails=characterDescriptionMode if scriptCount > 1 else False,
+			)
+			# END JP PATCH
 
 	@script(
 		# Translators: Input help mode message for left mouse click command.
@@ -410,7 +416,11 @@ class GlobalCommands(ScriptableObject):
 				return
 
 			elif len(info.text) < speech.speech.MAX_LENGTH_FOR_SELECTION_REPORTING:
-				speech.speakSpelling(info.text, useCharacterDescriptions=scriptCount > 1)
+				# BEGIN JP PATCH (character description mode)
+				speech.speakSpelling(
+					info.text, useCharacterDescriptions=scriptCount > 1, useDetails=scriptCount > 1
+				)
+				# END JP PATCH
 			else:
 				speech.speakTextSelected(info.text)
 				braille.handler.message(selectMessage)
@@ -1417,7 +1427,13 @@ class GlobalCommands(ScriptableObject):
 			text = " ".join(textList)
 			if len(text) > 0 and not text.isspace():
 				if scriptHandler.getLastScriptRepeatCount() == 1:
-					speech.speakSpelling(text)
+					# BEGIN JP PATCH (character description mode)
+					speech.speakSpelling(
+						text,
+						useCharacterDescriptions=characterDescriptionMode,
+						useDetails=characterDescriptionMode,
+					)
+					# END JP PATCH
 				else:
 					api.copyToClip(text, notify=True)
 		else:
@@ -2531,6 +2547,9 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		# Translators: Input help mode message for show NVDA menu command.
 		description=_("Shows the NVDA menu"),
+		# BEGIN JP PATCH
+		allowInSleepMode=True,
+		# END JP PATCH
 		gestures=("kb:NVDA+n", "ts:2finger_double_tap"),
 	)
 	@gui.blockAction.when(gui.blockAction.Context.MODAL_DIALOG_OPEN)
@@ -3989,7 +4008,11 @@ class GlobalCommands(ScriptableObject):
 			if repeatCount == 0:
 				ui.message(text)
 			else:
-				speech.speakSpelling(text, useCharacterDescriptions=repeatCount > 1)
+				# BEGIN JP PATCH (character description mode)
+				speech.speakSpelling(
+					text, useCharacterDescriptions=repeatCount > 1, useDetails=repeatCount > 1
+				)
+				# END JP PATCH
 		else:
 			ui.message(
 				ngettext(

--- a/source/installer.py
+++ b/source/installer.py
@@ -738,7 +738,6 @@ _nvdaExes = {
 	"nvda.exe",
 	"nvda_noUIAccess.exe",
 	"nvda_uiAccess.exe",
-	"nvda_dmp.exe",
 	"nvda_slave.exe",
 }
 

--- a/source/keyLabels.py
+++ b/source/keyLabels.py
@@ -167,6 +167,21 @@ localizedKeyLabels = {
 	"break": _("break"),
 	# Translators: This is the name of a key on the keyboard.
 	"tab": pgettext("keyLabel", "tab"),
+	# BEGIN JP PATCH
+	# nvdajp: IME key labels
+	# Translators: This is the name of a key on the keyboard.
+	"imenonconvert": _("IME non convert"),
+	# Translators: This is the name of a key on the keyboard.
+	"imeconvert": _("IME convert"),
+	# Translators: This is the name of a key on the keyboard.
+	"imechangestatus1": _("toggle input method"),
+	# Translators: This is the name of a key on the keyboard.
+	"imechangestatus2": _("toggle input method"),
+	# Translators: This is the name of a key on the keyboard.
+	"imechangestatus3": _("toggle input method"),
+	# Translators: This is the name of a key on the keyboard.
+	"pause": _("pause"),
+	# END JP PATCH
 }
 
 

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -63,6 +63,10 @@ class SpeechViewerFrame(
 
 		self._createControls(sizer=self.panelContentsSizer, parent=self.panel)
 
+		# BEGIN JP PATCH
+		# nvdajp: set window transparency (90% opacity)
+		self.SetTransparent(229)  # int(255.0 * 0.90)
+		# END JP PATCH
 		# Don't let speech viewer to steal keyboard focus when opened
 		self.ShowWithoutActivating()
 
@@ -105,6 +109,10 @@ class SpeechViewerFrame(
 		)
 		if isLockScreenModeActive():
 			self.shouldShowOnStartupCheckBox.Disable()
+		# BEGIN JP PATCH
+		# nvdajp: set window transparency (90% opacity)
+		self.SetTransparent(229)  # int(255.0 * 0.90)
+		# END JP PATCH
 
 	def _onDialogActivated(self, evt):
 		# Check for destruction, if the speechviewer window has focus when we exit NVDA it regains focus briefly

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -483,7 +483,10 @@ def getSynthInstance(name, asDefault=False):
 
 # The synthDrivers that should be used by default.
 # The first that successfully initializes will be used when config is set to auto (I.e. new installs of NVDA).
-defaultSynthPriorityList = ["oneCore", "espeak", "silence"]
+# BEGIN JP PATCH
+# nvdajp: use nvdajp_jtalk as the default Japanese synthesizer instead of espeak
+defaultSynthPriorityList = ["oneCore", "nvdajp_jtalk", "silence"]
+# END JP PATCH
 
 
 def setSynth(name: Optional[str], isFallback: bool = False):

--- a/source/synthDrivers/jtalk/_bgthread.py
+++ b/source/synthDrivers/jtalk/_bgthread.py
@@ -28,7 +28,6 @@ class BgThread(threading.Thread):
 
 	def run(self):
 		global isSpeaking
-		assert bgQueue is not None  # Type narrowing for type checkers
 		while True:
 			func, args, kwargs = bgQueue.get()
 			if not func:
@@ -44,7 +43,6 @@ class BgThread(threading.Thread):
 
 def execWhenDone(func, *args, **kwargs):
 	global bgQueue
-	assert bgQueue is not None  # Type narrowing for type checkers
 	# This can't be a kwarg in the function definition because it will consume the first non-keywor dargument which is meant for func.
 	mustBeAsync = kwargs.pop("mustBeAsync", False)
 	if mustBeAsync or bgQueue.unfinished_tasks != 0:
@@ -64,8 +62,6 @@ def initialize():
 
 def terminate():
 	global bgThread, bgQueue
-	assert bgQueue is not None  # Type narrowing for type checkers
-	assert bgThread is not None  # Type narrowing for type checkers
 	bgQueue.put((None, None, None))
 	bgThread.join()
 	bgThread = None

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -247,6 +247,10 @@ class OneCoreSynthDriver(SynthDriver):
 
 		self._wasCancelled = False
 		self._isProcessing = False
+		# BEGIN JP PATCH
+		# nvdajp: track speaking state for isSpeaking() method
+		self._isSpeaking = False
+		# END JP PATCH
 		# Initialize the voice to a sane default
 		self.voice = self._getDefaultVoice()
 		self._consecutiveSpeechFailures = 0
@@ -315,6 +319,10 @@ class OneCoreSynthDriver(SynthDriver):
 		if self._player:
 			self._player.open()
 		self._queueSpeech(text)
+		# BEGIN JP PATCH
+		# nvdajp: mark as speaking when speech is queued
+		self._isSpeaking = True
+		# END JP PATCH
 
 	def _queueSpeech(self, item: str) -> None:
 		self._queuedSpeech.append(item)
@@ -407,6 +415,10 @@ class OneCoreSynthDriver(SynthDriver):
 				log.debug("Calling idle on audio player")
 			self._player.idle()
 			synthDoneSpeaking.notify(synth=self)
+			# BEGIN JP PATCH
+			# nvdajp: mark as not speaking when speech is done
+			self._isSpeaking = False
+			# END JP PATCH
 		while self._queuedSpeech:
 			item = self._queuedSpeech.pop(0)
 			if isinstance(item, tuple):
@@ -626,6 +638,12 @@ class OneCoreSynthDriver(SynthDriver):
 	def pause(self, switch):
 		if self._player:
 			self._player.pause(switch)
+
+	# BEGIN JP PATCH
+	# nvdajp: provide isSpeaking() method to check if synthesizer is currently speaking
+	def isSpeaking(self):
+		return self._isSpeaking
+	# END JP PATCH
 
 
 # Alias to allow look up by name "SynthDriver"

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -113,6 +113,14 @@ class SynthDriverBufSink(COMObject):
 			if synth._bookmarks.popleft() == dwMarkNum:
 				break
 
+	# BEGIN JP PATCH
+	# nvdajp: notify when text data is done
+	def ITTSBufNotifySink_TextDataDone(self, this, qTimeStamp, dwMarkNum):
+		synth = self.synthRef()
+		if synth and hasattr(synth, "setSpeaking"):
+			synth.setSpeaking(False)
+	# END JP PATCH
+
 	def IUnknown_Release(self, this: int, *args, **kwargs):
 		if not self._allowDelete and self._refcnt.value == 1:
 			log.debugWarning("ITTSBufNotifySink::Release called too many times by engine")
@@ -918,6 +926,11 @@ class SynthDriver(SynthDriver):
 		self._volume = 100
 		self._paused = False
 		self.voice = str(self._enginesList[0].gModeID)
+		# BEGIN JP PATCH
+		# nvdajp: initialize rate cache and speaking state
+		self._rate = None
+		self._isSpeaking = False
+		# END JP PATCH
 
 	def terminate(self):
 		self._bufSink._allowDelete = True
@@ -953,12 +966,19 @@ class SynthDriver(SynthDriver):
 		lastHandledIndexInSequence = 0
 		for item in speechSequence:
 			if isinstance(item, str):
+				# BEGIN JP PATCH
+				# nvdajp: remove bullet characters that may cause issues with some SAPI4 voices
+				item = item.replace("\u2022", "").replace("\uf0b7", "")  # bullet
+				# END JP PATCH
 				textList.append(item.replace("\\", "\\\\"))
 			elif isinstance(item, IndexCommand):
 				textList.append("\\mrk=%d\\" % item.index)
 				bookmarks.append(item.index)
 				lastHandledIndexInSequence = item.index
-			elif isinstance(item, CharacterModeCommand):
+			# BEGIN JP PATCH
+			# nvdajp: disable CharacterModeCommand handling (False and ...)
+			elif False and isinstance(item, CharacterModeCommand):  # nvdajp
+			# END JP PATCH
 				textList.append("\\RmS=1\\" if item.state else "\\RmS=0\\")
 				charMode = item.state
 			elif isinstance(item, BreakCommand):
@@ -1001,10 +1021,18 @@ class SynthDriver(SynthDriver):
 			self._bufSinkPtr,
 			ITTSBufNotifySink._iid_,
 		)
+		# BEGIN JP PATCH
+		# nvdajp: mark as speaking when speech is queued
+		self._isSpeaking = True
+		# END JP PATCH
 
 	def cancel(self):
 		if isDebugForSynthDriver():
 			log.debug("SAPI4: Cancelling")
+		# BEGIN JP PATCH
+		# nvdajp: mark as speaking during cancel and clear lastIndex
+		self._isSpeaking = True
+		# END JP PATCH
 		try:
 			# cancel all pending bookmarks
 			self._bookmarkLists.clear()
@@ -1020,6 +1048,10 @@ class SynthDriver(SynthDriver):
 			log.debugWarning("Error cancelling speech", exc_info=True)
 		finally:
 			self._finalIndex = None
+			# BEGIN JP PATCH
+			# nvdajp: clear lastIndex on cancel
+			self.lastIndex = None
+			# END JP PATCH
 
 	def pause(self, switch: bool):
 		if isDebugForSynthDriver():
@@ -1035,6 +1067,15 @@ class SynthDriver(SynthDriver):
 		else:
 			self._ttsCentral.AudioResume()
 		self._paused = switch
+
+	# BEGIN JP PATCH
+	# nvdajp: provide setSpeaking and isSpeaking methods
+	def setSpeaking(self, switch):
+		self._isSpeaking = switch
+
+	def isSpeaking(self):
+		return self._isSpeaking
+	# END JP PATCH
 
 	def removeSetting(self, name):
 		# Putting it here because currently no other synths make use of it. OrderedDict, where you are?
@@ -1181,12 +1222,26 @@ class SynthDriver(SynthDriver):
 		return voices
 
 	def _get_rate(self) -> int:
+		# BEGIN JP PATCH
+		# nvdajp: use cached rate value if available
+		if self._rate is not None:
+			return self._rate
+		# END JP PATCH
 		val = DWORD()
 		self._ttsAttrs.SpeedGet(byref(val))
-		return self._paramToPercent(val.value, self._minRate, self._maxRate)
+		# BEGIN JP PATCH
+		# nvdajp: clamp rate to maximum 100%
+		ret = self._paramToPercent(val.value, self._minRate, self._maxRate)
+		return min(100, ret)
+		# END JP PATCH
 
 	def _set_rate(self, val: int):
+		# BEGIN JP PATCH
+		# nvdajp: cache rate value
+		self._rate = val
+		# END JP PATCH
 		val = self._percentToParam(val, self._minRate, self._maxRate)
+		val = min(self._maxRate, val)
 		self._ttsAttrs.SpeedSet(val)
 		self._rateDelta = val - self._defaultRate
 

--- a/tests/unit/contentRecog/test_contentRecog.py
+++ b/tests/unit/contentRecog/test_contentRecog.py
@@ -70,24 +70,27 @@ class TestLinesWordsResult(unittest.TestCase):
 		],
 	]
 	TOP = 0
-	BOTTOM = 23
-	WORD1_OFFSETS = (0, 6)
+	# BEGIN JP PATCH
+	# nvdajp: East Asian narrow characters don't have spaces between them
+	BOTTOM = 21
+	WORD1_OFFSETS = (0, 5)
 	WORD1_SECOND = 1
-	WORD1_LAST = 5
+	WORD1_LAST = 4
 	WORD1_RECT = RectLTWH(100, 200, 10, 20)
-	WORD2_START = 6
-	WORD2_OFFSETS = (6, 12)
+	WORD2_START = 5
+	WORD2_OFFSETS = (5, 11)
 	WORD2_RECT = RectLTWH(110, 200, 10, 20)
-	WORD3_OFFSETS = (12, 18)
-	WORD3_START = 12
+	WORD3_OFFSETS = (11, 16)
+	WORD3_START = 11
 	WORD3_RECT = RectLTWH(100, 220, 10, 20)
-	WORD4_OFFSETS = (18, 24)
+	WORD4_OFFSETS = (16, 22)
 	WORD4_RECT = RectLTWH(110, 220, 10, 20)
-	LINE1_OFFSETS = (0, 12)
+	LINE1_OFFSETS = (0, 11)
 	LINE1_SECOND = 1
-	LINE1_LAST = 11
-	LINE2_OFFSETS = (12, 24)
-	LINE2_START = 12
+	LINE1_LAST = 10
+	LINE2_OFFSETS = (11, 22)
+	LINE2_START = 11
+	# END JP PATCH
 
 	def setUp(self):
 		info = contentRecog.RecogImageInfo(0, 0, 1000, 2000, 1)
@@ -96,7 +99,10 @@ class TestLinesWordsResult(unittest.TestCase):
 		self.textInfo = self.result.makeTextInfo(self.fakeObj, textInfos.POSITION_FIRST)
 
 	def test_text(self):
-		self.assertEqual(self.result.text, "word1 word2\nword3 word4\n")
+		# BEGIN JP PATCH
+		# nvdajp: East Asian narrow characters don't have spaces between them
+		self.assertEqual(self.result.text, "word1word2\nword3word4\n")
+		# END JP PATCH
 
 	def test_textLen(self):
 		self.assertEqual(self.result.textLen, len(self.result.text))

--- a/tests/unit/test_synthDriverHandler.py
+++ b/tests/unit/test_synthDriverHandler.py
@@ -117,7 +117,10 @@ class test_synthDriverHandler(unittest.TestCase):
 		self.assertEqual(synthDriverHandler.getSynth().name, FAKE_DEFAULT_SYNTH_NAME)
 		synthDriverHandler.setSynth(None)  # reset the synth so there is no fallback
 		synthDriverHandler.setSynth("auto")
-		self.assertEqual(synthDriverHandler.getSynth().name, "espeak")
+		# BEGIN JP PATCH
+		# nvdajp: defaultSynthPriorityList includes nvdajp_jtalk instead of espeak
+		self.assertEqual(synthDriverHandler.getSynth().name, "nvdajp_jtalk")
+		# END JP PATCH
 
 	def test_synthChangedExtensionPoint(self):
 		expectedKwargs = dict(


### PR DESCRIPTION
## 概要

本家 2026.1 の日本語版へのマージに伴い、2025.3jp で正しい実装として受け入れられていた JP 固有コードを復活させました。

## 変更内容

### 1. ATOK とブライル表示の回避策の復活
- source/api.py: setFocusObject() 関数で、ATOK とブライル表示の組み合わせでの問題を回避するためのコードを復活
- ブライル表示がない場合は上流の実装に合わせて container を使用
- ブライル表示がある場合は parent を直接設定（ATOK とブライル表示の回避策）
- 関連チケット: ti33778, ti35974（JP 固有）、nvaccess ticket 3873, 4145 を revert

### 2. Windows 11 テキスト入力アプリの JP 固有 AppModule の復活
- source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py: JP 固有の AppModule を条件付きでインポートするコードを復活
- 
vdajpEnableKeyEvents 設定が有効な場合のみ、Windows 11 以上では _jp.py、Windows 10 では _jp_win10.py をインポート

### 3. 点字処理の JP 固有コードの復活
- source/braille.py: JP 固有の点字処理コードを復活
  - jpBrailleUtils からのインポートと関数群の復活
  - getPropertiesBraille() 関数内の JP 固有処理の復活
  - 他の関数での JP 固有関数の使用
  - NVDAObjectRegion.update() 内のテーブルヘッダー処理の復活

### 4. ドキュメント更新
- projectDocs/jp/changes-nvdajp.md: 変更内容をドキュメントに追記

## テスト結果

- ユニットテスト: 951個すべて通過（5個スキップ）

## 関連

- 2025.3jp からの移行で確認が必要な項目の一部を対応