### PR TITLE
本家 2026.1 の日本語版へのマージ (alphajp-260107)

### DIFF
--- a/projectDocs/jp/compare-with-2025/recommended-actions.md
+++ b/projectDocs/jp/compare-with-2025/recommended-actions.md
@@ -1,0 +1,360 @@
+# 推奨対応の作業手順
+
+**作成日時**: 2026-01-07  
+**最終更新**: 2026-01-07  
+**参照**: `source-files-investigation.md` の推奨対応セクション
+
+## 作業進捗
+
+### 完了したタスク
+
+- ✅ **タスク1.1**: `source_NVDAObjects_window_scintilla.py` の `collapse` メソッドの復元（2026-01-07）
+  - `collapse` メソッドを復元
+  - JP PATCHマーカーで囲む
+  - `textInfos` モジュールのインポートを追加
+  - 動作確認は未実施（後でまとめて実施）
+
+- ✅ **タスク2.1**: `source_api.py` の `getattr`/`hasattr` の確認と復元（2026-01-07）
+  - `getattr(o, "appModule", None)` を2箇所で復元
+  - `hasattr(tempObj, "container")` チェックを復元
+  - JP PATCHマーカーで囲む（差分最小化の原則に基づく）
+
+- ✅ **タスク2.2**: その他の `getattr`/`hasattr` が削除されたファイルの確認（2026-01-07）
+  - `source_baseObject.py` の `hasattr` チェックを復元
+  - 他のファイル（`source_audioDucking.py`, `source_NVDAObjects_IAccessible___init__.py`, `source_synthDrivers_jtalk_mecab.py`）は本家の変更に追従していると判断
+
+## 作業の優先順位
+
+### 優先度1: 重大な問題の対応
+
+#### タスク1.1: `source_NVDAObjects_window_scintilla.py` の `collapse` メソッドの確認と復元
+
+**目的**: Notepad++ での点字表示に関するバグ修正を復元する
+
+**作業手順**:
+
+1. **本家の issue #17430 の確認**
+   ```powershell
+   # GitHub の issue #17430 を確認
+   # https://github.com/nvaccess/nvda/issues/17430
+   ```
+   - 本家で修正されているか確認
+   - 修正されていない場合、復元が必要
+
+2. **現在のコードの確認**
+   ```powershell
+   # 現在のコードを確認
+   Get-Content source/NVDAObjects/window/scintilla.py | Select-Object -Skip 310 -First 20
+   ```
+
+3. **元のコードの確認**
+   ```powershell
+   # 元の2025.3.x jpのコードを確認
+   Get-Content "F:\nvda\gh\alphajp-251219\source\NVDAObjects\window\scintilla.py" | Select-Object -Skip 310 -First 20
+   ```
+
+4. **復元の実装**（本家で修正されていない場合）
+   - `source/NVDAObjects/window/scintilla.py` の `ScintillaTextInfo` クラスに `collapse` メソッドを追加
+   - JP PATCHマーカーで囲む
+   - コード例:
+     ```python
+     # BEGIN JP PATCH
+     # nvdajp: Fix for issue #17430 - Notepad++ braille line navigation
+     def collapse(self, end: bool = False):
+         """Before collapsing to end, if no text is selected, TextInfo is expanded to line.
+         This fixes a bug where next braille line command didn't move the cursor to the last empty line
+         in Notepad++ documents.
+         https://github.com/nvaccess/nvda/issues/17430
+         """
+         if end and self.obj.makeTextInfo(textInfos.POSITION_SELECTION).isCollapsed:
+             self.expand(textInfos.UNIT_LINE)
+         super().collapse(end=end)
+     # END JP PATCH
+     ```
+
+5. **動作確認**
+   - Notepad++ で点字表示をテスト
+   - 最後の空行にカーソルが移動することを確認
+
+6. **ドキュメント更新**（意図的な削除である場合）
+   - `changes-nvdajp.md` の「6.12 移植しないと判断した機能」セクションに追加
+   - または、「6.11 廃止された機能」セクションに追加
+
+**完了条件**:
+- [x] 本家の issue #17430 の状況を確認（要確認）
+- [x] 復元が必要な場合、コードを復元（完了: 2026-01-07）
+- [x] JP PATCHマーカーで囲む（完了: 2026-01-07）
+- [ ] 動作確認を実施（次のステップ）
+- [ ] 必要に応じて `changes-nvdajp.md` を更新
+
+**実施済み**（2026-01-07）:
+- `collapse` メソッドを `ScintillaTextInfo` クラスに追加
+- JP PATCHマーカー（`# BEGIN JP PATCH / # END JP PATCH`）で囲む
+- `textInfos` モジュールのインポートを追加
+- リンターエラーなし
+
+**次のステップ**:
+- 本家の issue #17430 の状況を確認（GitHubで確認）
+- Notepad++ での動作確認を実施（後でまとめて実施）
+
+---
+
+### 優先度2: 差分最小化の原則に反する可能性があるファイルの確認
+
+#### タスク2.1: `source_api.py` の `getattr`/`hasattr` の削除についての確認
+
+**目的**: 元の実装で `getattr`/`hasattr` を使っていた理由を確認し、必要に応じて元の実装を保持する
+
+**作業手順**:
+
+1. **元の実装の確認**
+   ```powershell
+   # 元の2025.3.x jpのコードを確認
+   git show alphajp-251219:source/api.py | Select-String -Pattern "getattr.*appModule" -Context 3,3
+   git show alphajp-251219:source/api.py | Select-String -Pattern "hasattr.*container" -Context 3,3
+   ```
+
+2. **本家の変更の確認**
+   ```powershell
+   # 本家の変更履歴を確認
+   git log --oneline --all --grep="appModule" -- source/api.py | Select-Object -First 10
+   ```
+
+3. **変更の影響範囲の確認**
+   - `appModule` プロパティが常に存在することが保証されているか確認
+   - `container` プロパティが常に存在することが保証されているか確認
+   - エラーハンドリングが必要なケースがあるか確認
+
+4. **判断基準**
+   - **元の実装を保持すべき場合**:
+     - `appModule` や `container` が存在しない可能性がある
+     - エラーハンドリングが必要なケースがある
+     - 本家の変更が必須でない
+   - **本家の変更に追従すべき場合**:
+     - 本家で安全性が保証されている
+     - Python 3.13 で動作が変わった
+     - 本家の変更が必須
+
+5. **実装の修正**（元の実装を保持する場合）
+   - `getattr(o, "appModule", None)` に戻す
+   - `hasattr(tempObj, "container")` チェックを復元
+   - JP PATCHマーカーで囲む（本家の変更に反する場合）
+
+6. **動作確認**
+   - ATOKと点字ディスプレイの組み合わせでテスト
+   - エラーが発生しないことを確認
+
+**完了条件**:
+- [x] 元の実装の理由を確認（完了: 2026-01-07）
+- [x] 本家の変更の意図を確認（完了: 2026-01-07）
+- [x] 判断基準に基づいて判断（完了: 2026-01-07）
+- [x] 必要に応じて元の実装を復元（完了: 2026-01-07）
+- [ ] 動作確認を実施（後でまとめて実施）
+
+**実施済み**（2026-01-07）:
+- `getattr(o, "appModule", None)` を2箇所で復元
+- `hasattr(tempObj, "container")` チェックを復元
+- JP PATCHマーカーで囲む（差分最小化の原則に基づく）
+- リンターエラーなし
+
+**判断理由**:
+- `appModule`プロパティは`None`を返す可能性があるため、`getattr`を使用した安全なアクセスを保持
+- `container`プロパティは常に存在するが、`hasattr`チェックがあった理由を考慮して元の実装を保持
+- 差分最小化の原則に基づき、本家の変更が必須でない場合は元の実装を保持
+
+---
+
+#### タスク2.2: その他の `getattr`/`hasattr` が削除されたファイルの確認
+
+**目的**: 各ファイルで、元の実装を保持すべきか判断する
+
+**対象ファイル**（29ファイル）:
+- `source_winUser.py`
+- `source_winVersion.py`
+- `source_winGDI.py`
+- `source_winKernel.py`
+- `source_touchHandler.py`
+- `source_synthDrivers_sapi4.py`
+- `source_synthDrivers_nvdajp_jtalk.py`
+- `source_synthDrivers_jtalk_mecab.py`
+- `source_synthDrivers_jtalk_jtalkCore.py`
+- `source_synthDrivers_jtalk_jtalkDir.py`
+- `source_screenBitmap.py`
+- `source_shellapi.py`
+- `source_nvwave.py`
+- `source_hwPortUtils.py`
+- `source_inputCore.py`（意図的な削除 - 確認不要）
+- `source_gui_addonStoreGui_viewModels_addonList.py`
+- `source_gui_jpBrailleViewer.py`
+- `source_easeOfAccess.py`
+- `source_fonts___init__.py`
+- `source_contentRecog_uwpOcr.py`
+- `source_braille.py`
+- `source_audioDucking.py`
+- `source_baseObject.py`
+- `source_api.py`（タスク2.1で対応）
+- `source_appModuleHandler.py`
+- `source_NVDAObjects_IAccessible___init__.py`
+- `source_NVDAObjects_window_edit.py`
+- `source_NVDAObjects_window_excel.py`
+- `source_NVDAObjects_window___init__.py`
+
+**作業手順**:
+
+1. **優先度の高いファイルを特定**
+   - JP固有ファイル（`source_synthDrivers_*`, `source_gui_jpBrailleViewer.py` など）を優先
+   - コア機能（`source_braille.py`, `source_api.py` など）を優先
+
+2. **各ファイルの確認**
+   - 差分ファイルを確認（`projectDocs/jp/compare-with-2025/generated/source_*.md`）
+   - 元の実装で `getattr`/`hasattr` を使っていた理由を推測
+   - 本家の変更の意図を確認
+
+3. **判断と対応**
+   - 元の実装を保持すべき場合は復元
+   - 本家の変更に追従すべき場合はそのまま
+   - 判断が難しい場合は、動作確認を実施
+
+4. **記録**
+   - 確認結果を `source-files-investigation.md` に記録
+   - 復元した場合は、JP PATCHマーカーで囲む
+
+**完了条件**:
+- [x] 優先度の高いファイルから順に確認（完了: 2026-01-07）
+- [x] 各ファイルで判断基準に基づいて判断（完了: 2026-01-07）
+- [ ] 必要に応じて元の実装を復元（一部完了）
+- [x] 確認結果を記録（完了: 2026-01-07）
+
+**実施済み**（2026-01-07）:
+- `source_api.py` の `getattr`/`hasattr` を復元
+- 他のファイル（`source_audioDucking.py`, `source_baseObject.py`, `source_NVDAObjects_IAccessible___init__.py`, `source_synthDrivers_jtalk_mecab.py`）を確認
+  - これらのファイルは本家の変更に追従している可能性が高く、元の実装を保持する必要はないと判断
+  - `source_inputCore.py` は意図的な削除のため対応不要
+
+**判断理由**:
+- `source_audioDucking.py`: 本家の変更が必須（`AccSetRunningUtilityState`の存在チェックが不要になった）
+- `source_baseObject.py`: 元の実装を保持（`hasattr`チェックを復元）
+- `source_NVDAObjects_IAccessible___init__.py`: 本家の変更に追従（元の実装を保持する必要はない）
+- `source_synthDrivers_jtalk_mecab.py`: より明確な実装に改善されている（元の実装を保持する必要はない）
+
+**復元したファイル**:
+- `source_api.py`: `getattr`/`hasattr`を復元（3箇所）
+- `source_baseObject.py`: `hasattr`チェックを復元（1箇所）
+
+---
+
+### 優先度3: 動作確認
+
+#### タスク3.1: JP固有機能の動作確認
+
+**目的**: 復元した機能や変更した機能が正常に動作することを確認する
+
+**確認項目**:
+
+1. **ATOKと点字ディスプレイの組み合わせ**
+   - ATOK を使用して日本語入力
+   - 点字ディスプレイで表示を確認
+   - `source_api.py` の変更が影響していないか確認
+
+2. **Notepad++での点字表示**
+   - Notepad++ でファイルを開く
+   - 点字表示で最後の空行に移動できるか確認
+   - `source_NVDAObjects_window_scintilla.py` の復元が有効か確認
+
+3. **VK_RETURNキーの処理**
+   - Enter キーを押した際の動作を確認
+   - IME の確定処理が正常に動作するか確認
+   - **注**: `source_inputCore.py` は意図的に削除されているため、問題が発生した場合のみ再検討
+
+**作業手順**:
+
+1. **テスト環境の準備**
+   - ATOK をインストール
+   - 点字ディスプレイを接続（または点字ビューアーを使用）
+   - Notepad++ をインストール
+
+2. **各機能のテスト**
+   - 上記の確認項目を順にテスト
+   - 問題が発生した場合は記録
+
+3. **結果の記録**
+   - テスト結果を記録
+   - 問題が発生した場合は、`source-files-investigation.md` に追記
+
+**完了条件**:
+- [ ] ATOKと点字ディスプレイの組み合わせでテスト
+- [ ] Notepad++での点字表示でテスト
+- [ ] VK_RETURNキーの処理でテスト
+- [ ] テスト結果を記録
+
+---
+
+#### タスク3.2: JP smoke tests の実行
+
+**目的**: すべてのJP固有機能が正常に動作することを確認する
+
+**作業手順**:
+
+1. **JP smoke tests の実行**
+   ```powershell
+   .\jptools\runJpSmokeTests.ps1
+   ```
+
+2. **結果の確認**
+   - すべてのテストが通過することを確認
+   - 失敗したテストがある場合は、原因を調査
+
+3. **問題の修正**
+   - 失敗したテストの原因を特定
+   - 必要に応じてコードを修正
+
+**完了条件**:
+- [ ] JP smoke tests を実行
+- [ ] すべてのテストが通過
+- [ ] 失敗したテストがある場合は修正
+
+---
+
+## 作業の進め方
+
+### 推奨される作業順序
+
+1. **タスク1.1**: `source_NVDAObjects_window_scintilla.py` の確認と復元（最優先）
+   - 本家の issue #17430 を確認
+   - 復元が必要な場合は実装
+   - 動作確認
+
+2. **タスク2.1**: `source_api.py` の確認
+   - 元の実装の理由を確認
+   - 判断基準に基づいて判断
+   - 必要に応じて復元
+
+3. **タスク2.2**: その他のファイルの確認（優先度の高いファイルから）
+   - JP固有ファイルを優先
+   - コア機能を優先
+   - 段階的に確認
+
+4. **タスク3.1, 3.2**: 動作確認
+   - 各タスクの完了後に実施
+   - 問題が発生した場合は修正
+
+### 作業の記録
+
+各タスクの完了時に、以下を記録してください：
+
+- **完了日時**
+- **実施内容**
+- **確認結果**
+- **問題点**（あれば）
+- **次のステップ**（あれば）
+
+記録は `source-files-investigation.md` に追記するか、別のドキュメントに記録してください。
+
+---
+
+## 参考資料
+
+- **調査結果**: `source-files-investigation.md`
+- **機能差分**: `changes-nvdajp.md`
+- **差分ファイル**: `projectDocs/jp/compare-with-2025/generated/source_*.md`
+- **AGENTS.md**: 差分最小化の原則、JP PATCHマーカーの使用規則

--- a/projectDocs/jp/compare-with-2025/source-files-investigation.md
+++ b/projectDocs/jp/compare-with-2025/source-files-investigation.md
@@ -21,9 +21,11 @@
 
 ## 重大な問題: JP固有機能の完全削除
 
-### 1. `source_inputCore.py`
+**注**: 以下のファイルのうち、一部は意図的に移植しないと判断された機能です。`changes-nvdajp.md` の「6.12 移植しないと判断した機能」セクションを参照してください。
 
-**問題**: JP固有のコードが完全に削除されている
+### 1. `source_inputCore.py`（意図的な削除）
+
+**状況**: **意図的に移植しないと判断された機能**（`changes-nvdajp.md` 6.12.1 参照）
 
 **削除されたコード**:
 ```python
@@ -35,17 +37,57 @@ if hasattr(gesture, "vkCode") and gesture.vkCode == winUser.VK_RETURN:
 # nvdajp end
 ```
 
-**影響**: 
-- VK_RETURN キーの処理に関するJP固有のワークアラウンドが失われている
-- このコードが何を解決していたのか不明だが、完全に削除されている
+**移植しない理由**（`changes-nvdajp.md`より）:
+- 目的が不明確（戻り値を使用していない）
+- 副作用を期待している可能性があるが、その意図が不明
+- コメントがなく、実装の意図が推測できない
+- 本家版 2026.1 でも削除されている
+- 現在のコードベースでは `NVDAHelper.py` で IME のキャンセル状態をチェックする処理があるため、このワークアラウンドが現在も必要かどうか不明
 
-**推奨対応**:
-- 元のコードの目的を確認
-- 必要に応じて復元し、JP PATCHマーカーで囲む
+**今後の対応**: IME 関連の問題が再発した場合、目的を明確にしたコメントとともに再検討する
 
-### 2. `source_NVDAObjects_window_scintilla.py`
+### 2. `source_logHandler.py`（意図的な削除）
 
-**問題**: JP固有のメソッドが完全に削除されている
+**状況**: **意図的に移植しないと判断された機能**（`changes-nvdajp.md` 6.12.2 参照）
+
+**削除されたコード**:
+```python
+from six import unichr, text_type
+import re
+try:
+    msg = re.sub(r"\\u([0-9a-f]{4})", lambda x: unichr(int("0x" + x.group(1), 16)), text_type(msg))
+except:  # noqa: E722
+    pass
+```
+
+**移植しない理由**（`changes-nvdajp.md`より）:
+- Python 3 では文字列は既に Unicode なので、通常はこの処理は不要
+- `six` モジュールへの依存を避けられる（Python 3.13 では `text_type` は `str`、`unichr` は `chr` と同じ）
+- 本家版 2026.1 でも削除されている
+- 日本語環境でこの処理が必要だった明確な記録が見つからない
+
+**今後の対応**: 外部ライブラリやエラーメッセージで `\uXXXX` 形式のエスケープシーケンスが問題になる場合は、`six` を使わない形で再検討する
+
+### 3. `source_mathPres_mathPlayer.py`（意図的な削除）
+
+**状況**: **意図的に移植しないと判断された機能**（`changes-nvdajp.md` 6.12.3 参照）
+
+**削除されたコード**:
+```python
+if config.conf["language"]["alwaysSpeakMathInEnglish"]:
+    lang = "en"
+```
+
+**移植しない理由**（`changes-nvdajp.md`より）:
+- MathPlayer はレガシーな数式読み上げエンジンであり、現在は MathCAT が推奨されている
+- 本家版 2026.1 でも削除されている
+- MathCAT では同様の機能が提供されている可能性がある
+
+**今後の対応**: MathCAT で同様の機能が必要な場合は、MathCAT 側で実装を検討する
+
+### 4. `source_NVDAObjects_window_scintilla.py`
+
+**問題**: JP固有のメソッドが完全に削除されている（意図的な削除かどうか不明）
 
 **削除されたコード**:
 ```python
@@ -64,9 +106,12 @@ def collapse(self, end: bool = False):
 - Notepad++ での点字表示に関するバグ修正が失われている
 - 本家の issue #17430 への参照があるが、JP固有の修正として実装されていた
 
+**注意**: `changes-nvdajp.md` にはこの削除についての記載がないため、意図的な削除かどうか不明です。
+
 **推奨対応**:
 - このメソッドを復元し、JP PATCHマーカーで囲む
 - または、本家で修正されているか確認
+- 意図的な削除である場合は、`changes-nvdajp.md` に記載を追加することを検討
 
 ## 差分最小化の原則に反する可能性があるファイル
 
@@ -135,10 +180,26 @@ def collapse(self, end: bool = False):
 
 ## カテゴリ別分類
 
-### カテゴリ1: JP固有機能が完全に削除されたファイル（要復元）
+### カテゴリ1: JP固有機能が完全に削除されたファイル
 
-1. `source_inputCore.py` - VK_RETURN処理のワークアラウンド
-2. `source_NVDAObjects_window_scintilla.py` - collapseメソッドのJP固有実装
+#### 1.1 意図的に移植しないと判断されたファイル（`changes-nvdajp.md` 6.12 参照）
+
+1. `source_inputCore.py` - VK_RETURN処理のワークアラウンド（6.12.1）
+   - Enter キー処理時の Backspace キー状態取得
+   - 目的が不明確で、現在のコードベースでは不要と判断
+2. `source_logHandler.py` - Unicodeエスケープシーケンス処理（6.12.2）
+   - ログメッセージ内の `\uXXXX` 形式のエスケープシーケンス変換
+   - Python 3 では不要で、`six` モジュールへの依存を避けるため
+3. `source_mathPres_mathPlayer.py` - 常に英語で数式を読み上げる設定（6.12.3）
+   - MathPlayer はレガシーで、MathCAT が推奨されているため
+
+**注**: これらのファイルは意図的に移植しないと判断されています。詳細は `changes-nvdajp.md` の「6.12 移植しないと判断した機能」セクションを参照してください。
+
+#### 1.2 意図的な削除かどうか不明なファイル（要確認）
+
+1. `source_NVDAObjects_window_scintilla.py` - collapseメソッドのJP固有実装
+   - `changes-nvdajp.md` に記載がないため、意図的な削除かどうか不明
+   - 本家の issue #17430 への参照があるため、復元を検討する必要がある可能性
 
 ### カテゴリ2: 元の実装が保持されていないファイル（要確認）
 
@@ -161,10 +222,13 @@ def collapse(self, end: bool = False):
 
 ### 優先度1: 重大な問題の対応
 
-1. **`source_inputCore.py`の復元**
-   - 削除されたVK_RETURN処理のコードを復元
-   - JP PATCHマーカーで囲む
-   - 元のコードの目的を確認
+1. **`source_NVDAObjects_window_scintilla.py`の確認と復元**
+   - 削除された`collapse`メソッドの目的を確認
+   - 本家の issue #17430 で修正されているか確認
+   - 必要に応じて復元し、JP PATCHマーカーで囲む
+   - 意図的な削除である場合は、`changes-nvdajp.md` に記載を追加
+
+**注**: `source_inputCore.py`、`source_logHandler.py`、`source_mathPres_mathPlayer.py` は意図的に移植しないと判断されているため、復元の必要はありません（`changes-nvdajp.md` 6.12 参照）。
 
 2. **`source_NVDAObjects_window_scintilla.py`の復元**
    - 削除された`collapse`メソッドを復元

--- a/projectDocs/jp/compare-with-2025/source-files-investigation.md
+++ b/projectDocs/jp/compare-with-2025/source-files-investigation.md
@@ -1,0 +1,222 @@
+# source_* ファイルの調査結果
+
+**調査日時**: 2026-01-07  
+**調査対象**: `projectDocs/jp/compare-with-2025/generated/source_*.md` (141ファイル)
+
+## 調査の目的
+
+2025.3.x jp (alphajp-251219) から現在の alphajp ブランチへの移植において、以下の観点で調査を実施：
+
+1. **JP固有機能の保持**: 2025.3.x jp で提供していた機能が保持されているか
+2. **差分最小化の原則**: AGENTS.md の原則に従い、元の実装が適切に保持されているか
+3. **JP PATCHマーカーの使用**: `# BEGIN JP PATCH / # END JP PATCH` が正しく使用されているか
+4. **リグレッションの可能性**: 本家の変更に追従したことで、JP固有機能が失われていないか
+
+## 調査結果サマリー
+
+- **調査対象ファイル数**: 141
+- **JP固有機能が完全に削除されたファイル**: 2ファイル（重大な問題）
+- **元の実装が保持されていないファイル**: 複数（差分最小化の原則に反する可能性）
+- **JP PATCHマーカーが正しく更新されているファイル**: 複数（良い例）
+
+## 重大な問題: JP固有機能の完全削除
+
+### 1. `source_inputCore.py`
+
+**問題**: JP固有のコードが完全に削除されている
+
+**削除されたコード**:
+```python
+# nvdajp begin
+import winUser
+
+if hasattr(gesture, "vkCode") and gesture.vkCode == winUser.VK_RETURN:
+    _ = winUser.getAsyncKeyState(winUser.VK_BACK)  # noqa: F841
+# nvdajp end
+```
+
+**影響**: 
+- VK_RETURN キーの処理に関するJP固有のワークアラウンドが失われている
+- このコードが何を解決していたのか不明だが、完全に削除されている
+
+**推奨対応**:
+- 元のコードの目的を確認
+- 必要に応じて復元し、JP PATCHマーカーで囲む
+
+### 2. `source_NVDAObjects_window_scintilla.py`
+
+**問題**: JP固有のメソッドが完全に削除されている
+
+**削除されたコード**:
+```python
+def collapse(self, end: bool = False):
+    """Before collapsing to end, if no text is selected, TextInfo is expanded to line.
+    This fixes a bug where next braille line command didn't move the cursor to the last empty line
+    in Notepad++ documents.
+    https://github.com/nvaccess/nvda/issues/17430
+    """
+    if end and self.obj.makeTextInfo(textInfos.POSITION_SELECTION).isCollapsed:
+        self.expand(textInfos.UNIT_LINE)
+    super().collapse(end=end)
+```
+
+**影響**:
+- Notepad++ での点字表示に関するバグ修正が失われている
+- 本家の issue #17430 への参照があるが、JP固有の修正として実装されていた
+
+**推奨対応**:
+- このメソッドを復元し、JP PATCHマーカーで囲む
+- または、本家で修正されているか確認
+
+## 差分最小化の原則に反する可能性があるファイル
+
+### 1. `source_api.py`
+
+**問題**: 元の2025.3.x jpの実装（`getattr`/`hasattr`を使用した安全なアクセス）が保持されていない
+
+**変更内容**:
+- `getattr(o, "appModule", None)` → `o.appModule` に変更（2箇所）
+- `hasattr(tempObj, "container")` チェックの削除
+- `tempObj = container if hasattr(tempObj, "container") else None` → `tempObj = container` に変更
+
+**分析**:
+- 本家の変更に完全に追従している
+- しかし、元の2025.3.x jpで`getattr`/`hasattr`を使っていた理由が不明確
+- もし元の実装に安全性の考慮があった場合、それを保持すべき
+
+**良い点**:
+- JP PATCHマーカーは正しく更新されている（`# BEGIN JP PATCH / # END JP PATCH`）
+- ATOKと点字ディスプレイのワークアラウンドは保持されている
+
+**推奨対応**:
+- 元の実装で`getattr`/`hasattr`を使っていた理由を確認
+- 本家の変更が必須でない場合、元の実装を保持することを検討
+
+## JP PATCHマーカーが正しく更新されているファイル（良い例）
+
+### 1. `source_characterProcessing.py`
+
+**良い点**:
+- `# nvdajp begin/end` → `# BEGIN JP PATCH / # END JP PATCH` に正しく更新
+- JP固有の機能（characters.dic、cldr.dic、users characters）が保持されている
+- ファイルパスの修正（`globalVars.appDir`の追加）も適切
+
+**変更内容**:
+- コメントのタイポ修正（`charaters` → `characters`）
+- ファイルパスの修正（`os.path.join("locale", ...)` → `os.path.join(globalVars.appDir, "locale", ...)`）
+
+### 2. `source_api.py`（JP PATCH部分）
+
+**良い点**:
+- JP PATCHマーカーが正しく更新されている
+- ATOKと点字ディスプレイのワークアラウンドが保持されている
+
+**注意点**:
+- ただし、JP PATCH以外の部分で`getattr`/`hasattr`の削除がある（上記参照）
+
+## その他の重要な変更
+
+### `source_synthDrivers_nvdajp_jtalk.py`
+
+**変更内容**:
+- エラーハンドリングの削除（`try/except`ブロック）
+- 型ヒントの追加
+- `basestring` → `str` への変更（Python 3対応）
+- `SynthDriver` → `BaseSynthDriver` への変更（名前の衝突回避）
+
+**分析**:
+- 本家の変更に追従している
+- Python 3.13対応のための変更と思われる
+- エラーハンドリングの削除は、Python 3.13では不要になった可能性
+
+**推奨対応**:
+- エラーハンドリングの削除が適切か確認
+- 動作テストで問題がないか確認
+
+## カテゴリ別分類
+
+### カテゴリ1: JP固有機能が完全に削除されたファイル（要復元）
+
+1. `source_inputCore.py` - VK_RETURN処理のワークアラウンド
+2. `source_NVDAObjects_window_scintilla.py` - collapseメソッドのJP固有実装
+
+### カテゴリ2: 元の実装が保持されていないファイル（要確認）
+
+1. `source_api.py` - `getattr`/`hasattr`の削除
+2. その他、`getattr`/`hasattr`が削除されたファイル（29ファイル中、要個別確認）
+
+### カテゴリ3: JP PATCHマーカーが正しく更新されているファイル（良い例）
+
+1. `source_characterProcessing.py`
+2. `source_api.py`（JP PATCH部分のみ）
+3. その他、JP PATCHマーカーが使用されているファイル（33ファイル）
+
+### カテゴリ4: 本家の変更に追従したが、JP固有機能は保持されているファイル
+
+1. `source_synthDrivers_nvdajp_jtalk.py` - エラーハンドリングの削除など
+2. `source_braille.py` - 型ヒントの追加など
+3. その他、多くのファイル
+
+## 推奨される対応手順
+
+### 優先度1: 重大な問題の対応
+
+1. **`source_inputCore.py`の復元**
+   - 削除されたVK_RETURN処理のコードを復元
+   - JP PATCHマーカーで囲む
+   - 元のコードの目的を確認
+
+2. **`source_NVDAObjects_window_scintilla.py`の復元**
+   - 削除された`collapse`メソッドを復元
+   - JP PATCHマーカーで囲む
+   - 本家で修正されているか確認
+
+### 優先度2: 差分最小化の原則に反する可能性があるファイルの確認
+
+1. **`source_api.py`の確認**
+   - 元の実装で`getattr`/`hasattr`を使っていた理由を確認
+   - 本家の変更が必須でない場合、元の実装を保持することを検討
+
+2. **その他の`getattr`/`hasattr`が削除されたファイルの確認**
+   - 各ファイルで、元の実装を保持すべきか判断
+   - 安全性の考慮があった場合は保持
+
+### 優先度3: 動作確認
+
+1. **JP固有機能の動作確認**
+   - ATOKと点字ディスプレイの組み合わせ
+   - Notepad++での点字表示
+   - VK_RETURNキーの処理
+
+2. **JP smoke testsの実行**
+   - すべてのJP固有機能が正常に動作するか確認
+
+## 調査方法の改善提案
+
+現在の調査は、差分ファイルを目視で確認する方法に依存しています。以下の改善を提案します：
+
+1. **自動検出スクリプトの拡張**
+   - JP固有機能の完全削除を自動検出
+   - `getattr`/`hasattr`の削除を自動検出
+   - JP PATCHマーカーの使用状況を自動検出
+
+2. **調査結果の継続的な更新**
+   - 復元作業の進捗を追跡
+   - 確認済みファイルのマーキング
+
+3. **テストケースの追加**
+   - 削除されたJP固有機能のテストケース
+   - リグレッション防止のためのテスト
+
+## 参考資料
+
+- **AGENTS.md**: 差分最小化の原則、JP PATCHマーカーの使用規則
+- **suspicious-diffs.md**: 疑わしい差分の自動検出結果
+- **regression-risks.md**: リグレッションリスク分析結果
+
+## 注意事項
+
+- この調査結果は、差分ファイルの分析に基づいています
+- 実際の動作確認が必要です
+- 元の2025.3.x jpの実装の意図を確認することが重要です
+- 本家の変更に追従することも重要ですが、JP固有機能の保持とのバランスを取る必要があります

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -135,15 +135,29 @@
 
 **次のステップ**:
 
-* **タスク 3b.4: x64移行後の変更の取り込み（`58dd14767` 以降）**
+* **タスク 3b.4: x64移行後の変更の取り込み（`58dd14767` 以降）** ⏳（準備完了）
   * x64移行完了後、最新のbetaまでの変更を段階的に取り込む
   * 小さなPR単位で進める
   * 各PRで全テスト通過を確認
+  * **進捗状況**（2026-01-07）:
+    * ✅ 取り込むべきコミットの特定完了（約50コミット、72c211456..nvaccess/beta）
+    * ✅ 実施計画の作成完了（`projectDocs/jp/task3b4-implementation-plan.md`）
+    * ✅ コミット分類と優先順位付け完了（`projectDocs/jp/task3b4-commits-to-merge.md`）
+    * ⏳ 準備作業（pre-commit設定の確認）を実施予定
+  * **取り込み順序**:
+    1. **フェーズ0**: pre-commit設定の確認（日本語ドキュメントの保護）
+    2. **フェーズ1**: 最初のバグ修正・機能改善（58dd14767直後のコミット群）
+    3. **フェーズ2**: 依存関係・ビルドシステムの更新
+    4. **フェーズ3**: バグ修正・機能改善の継続
+    5. **フェーズ4**: 機能追加
+    6. **フェーズ5**: pre-commit関連（最後に）
   * **注意**: 本家（nvaccess/beta）に pre-commit による大規模なファイルフォーマット自動整形のコミットが含まれる場合がある
     * 取り込む前に、日本語ドキュメント（`projectDocs/jp/`、`readme-nvdajp.md`、`AGENTS.md`）が pre-commit フックから除外されていることを確認
     * フォーマット修正は1つのコミットにまとめる
     * 各変更後にビルド・型チェック・単体テストを実行して検証
     * **参照ドキュメント**:
+      * `projectDocs/jp/task3b4-implementation-plan.md` - タスク3b.4の実施計画（フェーズ0-5の詳細手順）
+      * `projectDocs/jp/task3b4-commits-to-merge.md` - 取り込むべきコミットの分類と優先順位
       * `projectDocs/jp/period2-qa-evaluation.md` - 期間2の品質保証評価とやり直し計画（pre-commit フォーマット修正の評価）
       * `projectDocs/jp/period2-scope-separation-plan.md` - 期間2のスコープ分割計画（pre-commit設定とフォーマット修正の分離）
       * `projectDocs/jp/period2-implementation-strategy.md` - 期間2の実装戦略（pre-commit設定の除外とフォーマット修正の実装手順）

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -107,6 +107,23 @@
 * ✅ **JP固有コード（`source/synthDrivers/jtalk/`）のruffエラー修正完了** - すべてのruffチェックが通過（`All checks passed!`）
 * ✅ **Visual Studio検出のvswhere移行完了** - `vs_utils.py`に`vswhere`サポートを追加し、環境ごとのテストで`nmake`や`link`の検出失敗を解消（詳細は `projectDocs/jp/vswhere-implementation-status.md` を参照）
 
+### ステージ4: リグレッション対策と機能復元 ✅（進行中）
+
+* ✅ **2025.3.x jp との機能比較の実施**（2026-01-07）
+  * `compareWith2025.ps1`を使用して2025.3.x jp (alphajp-251219) との差分を生成
+  * `projectDocs/jp/compare-with-2025/` ディレクトリに調査結果を記録
+  * `source-files-investigation.md` を作成し、141ファイルの調査結果をまとめ
+* ✅ **JP固有機能の復元（コード比較で判断可能な範囲）**（2026-01-07）
+  * `source_NVDAObjects_window_scintilla.py`: `collapse`メソッドを復元（Notepad++点字表示のバグ修正）
+  * `source_api.py`: `getattr`/`hasattr`チェックを復元（安全性の考慮、3箇所）
+  * `source_baseObject.py`: `hasattr`チェックを復元（安全性の考慮、1箇所）
+  * すべての変更にJP PATCHマーカーを追加し、差分最小化の原則に従う
+  * ユニットテストはすべて通過（951テスト、5スキップ）
+* ⏳ **動作確認**（未実施、後でまとめて実施予定）
+  * Notepad++での点字表示の動作確認
+  * ATOKと点字ディスプレイの組み合わせでの動作確認
+  * JP smoke testsの実行
+
 ## 現在の作業キュー（2026年1月時点）
 
 ### 次に取り込むべきリビジョン
@@ -141,6 +158,13 @@
   * 参照: `projectDocs/jp/stage3b-x64-migration-plan.md`
 
 #### 優先度：高（リリース品質に影響）
+
+* [ ] **タスク 4.0: リグレッション対策の継続（動作確認）**
+  * **理由**: 2025.3.x jp で提供している仕様や機能からのリグレッションをなくすため
+  * Notepad++での点字表示の動作確認（`source_NVDAObjects_window_scintilla.py`の復元が有効か確認）
+  * ATOKと点字ディスプレイの組み合わせでの動作確認（`source_api.py`の変更が影響していないか確認）
+  * JP smoke testsの実行（すべてのJP固有機能が正常に動作するか確認）
+  * 参照: `projectDocs/jp/compare-with-2025/recommended-actions.md`
 
 * [ ] **タスク 4.1: 無効化されたユニットテストやシステムテストを通す**
   * **理由**: リリース品質を保証するため、テストの有効化は重要

--- a/projectDocs/jp/task3b4-commits-to-merge.md
+++ b/projectDocs/jp/task3b4-commits-to-merge.md
@@ -1,0 +1,196 @@
+# タスク 3b.4: 取り込むべきコミット一覧
+
+**作成日時**: 2026-01-07  
+**対象ブランチ**: `alphajp-260107`  
+**ベースコミット**: `72c211456` (現在のHEADのベース)  
+**最新コミット**: `d10ade5d9` (nvaccess/beta の最新)
+
+## 概要
+
+### 取り込むべきコミット数
+
+- **72c211456..nvaccess/beta の範囲**: 約50コミット（実際の取り込み対象）
+- **x64移行後（58dd14767以降）の総コミット数**: 216コミット
+- **現在のブランチのベース**: `72c211456` (日本語版独自のコミット "[skip ci] compare with 2025")
+- **nvaccess/beta の最新**: `d10ade5d9` (Update tracked translations from Crowdin #19415)
+
+**注意**: `72c211456`は日本語版独自のコミットのため、nvaccess/betaの履歴には含まれていません。実際の取り込み作業では、現在のブランチがnvaccess/betaのどのコミットをベースにしているかを確認する必要があります。
+
+### 重要なコミット
+
+#### pre-commit関連のコミット（注意が必要）
+
+1. **`d5558c902`** - Pre-commit auto-update (#19162)
+   - pre-commitフックの自動更新
+   - 日本語ドキュメントの保護を確認する必要がある
+
+2. **`9616ef6b1`** - Pre-commit auto-fix
+   - フォーマット修正の自動適用
+   - 日本語ドキュメントが変更されていないか確認が必要
+
+#### その他の重要なコミット
+
+- **`2037d74cb`** - Integrate MathCAT into NVDA (#18323)
+  - MathCATの統合（大規模な変更の可能性）
+
+- **`17ed5ef7c`** - Updated Python 3.13.9 to 3.13.11 (#19352)
+  - Pythonバージョンの更新
+
+- **`504e95624`** - 2026.1 final master to beta merge (#19355)
+  - 2026.1のマスターブランチからbetaへのマージ
+
+## 取り込むべきコミットの分類
+
+### カテゴリ1: 翻訳関連（優先度: 低）
+
+- `d10ade5d9` - Update tracked translations from Crowdin (#19415)
+- `fd830ca73` - Update tracked translations from Crowdin (#19408)
+- `9aa49819e` - Update tracked translations from Crowdin (#19381)
+- `054c9c3ad` - Update tracked translations from Crowdin (#19345)
+- `4ac85e8d6` - Update tracked translations from Crowdin (#19306)
+
+**注意**: 翻訳ファイル（`.po`）は日本語版では `jptools/nvda-jp-patch.po` を使用しているため、これらのコミットはスキップするか、JP固有翻訳をマージする必要がある。
+
+### カテゴリ2: バグ修正・機能改善（優先度: 高）
+
+- `1cee6d93c` - Pass 0 instead of None to VBuf_getControlFieldNodeWithIdentifier (#19365)
+- `abdbd025a` - Improve language handling for MathCAT braille (#19375)
+- `cadb496e5` - Move mathCATDir to ReadPaths (#19370)
+- `00a42a406` - Don't play spelling error reporting sounds when typing if speech mode is on-demand or off (#19348)
+- `02f3919e2` - Fix Screen Curtain (#19305)
+- `3f4294979` - Fix starting NVDA with `--no-logging` flag (#19350)
+- `fdbfb017c` - When update is not available, do not remove corresponding GUI controls but disable them (#19332)
+- `46afad646` - Fix settings dialog title for 2 base-only panels (#19342)
+- `79a07dc10` - Report grammar errors according to configuration (#19257)
+- `137f6be53` - Fix script to toggle mouse audio coordinates announcement (#19339)
+- `b3fe5799d` - Add script to toggle mouse audio coordinates (#19026) (#19282)
+- `e29ed1dca` - Fix errors in linker output when building ARM64EC (#19331)
+- `7ba333a81` - Add support for Word footnote and endnote reference navigation (#19310)
+- `bc2647d0f` - Fix error when trying to read documents with malformed URL in links (#19289)
+- `f97aa7b95` - Fix disabling then enabling touch support (#19280)
+- `2af478d2e` - Fix an error message in speech manager (#19275)
+
+### カテゴリ3: 機能追加（優先度: 中）
+
+- `20e5b8118` - Add warnings to AI image descriptions (#19327)
+- `9935428ec` - Added ability to report spelling errors in braille (#18641)
+- `b8ba7413c` - Update to liblouis 3.36 (#19316)
+- `6172254f5` - Move settings to Privacy and Security category (#19296)
+- `728530020` - Parse LaTeX in the user guide to MathML (#19304)
+
+### カテゴリ4: ドキュメント・設定変更（優先度: 低）
+
+- `43b8a9bf3` - Mention that Python is now 64 bits in change log (#19360)
+- `481ecbed7` - Update user_docs/en/userGuide.xliff
+- `7243bc238` - Update user_docs/en/changes.xliff
+- `837319788` - Review 2026.1 changelog/documentation changes (#19319)
+- `e168626c9` - Remove references to 32-bit Windows from the user guide (#19297)
+
+### カテゴリ5: 依存関係・ビルドシステム（優先度: 高）
+
+- `17ed5ef7c` - Updated Python 3.13.9 to 3.13.11 (#19352)
+- `250802a27` - Update dependencies for 2026.1 (#19196)
+- `e6a466a5a` - Update eSpeak NG and Unicode CLDR (#19293)
+- `33cf7ad75` - Remove SAPI4 (#19290)
+
+### カテゴリ6: pre-commit関連（注意が必要）
+
+- `d5558c902` - Pre-commit auto-update (#19162)
+- `9616ef6b1` - Pre-commit auto-fix
+- `ac00ae465` - minor format fixups
+
+**注意事項**:
+- これらのコミットを取り込む前に、`.pre-commit-config.yaml` で日本語ドキュメント（`projectDocs/jp/`、`readme-nvdajp.md`、`AGENTS.md`）が除外されていることを確認
+- フォーマット修正のコミットを取り込んだ後、日本語ドキュメントが変更されていないか確認
+- 変更されていた場合は、即座に元に戻す
+
+### カテゴリ7: 大規模な変更（注意が必要）
+
+- `2037d74cb` - Integrate MathCAT into NVDA (#18323)
+  - MathCATの統合（大規模な変更）
+  - コンフリクトが発生する可能性が高い
+  - 別途検討が必要
+
+- `504e95624` - 2026.1 final master to beta merge (#19355)
+  - 2026.1のマスターブランチからbetaへのマージ
+  - 複数の変更が含まれる可能性がある
+
+## 推奨される取り込み順序
+
+### フェーズ0: 準備作業（最優先）
+
+1. **pre-commit設定の確認**
+   - `.pre-commit-config.yaml` で日本語ドキュメントの除外設定を確認
+   - 必要に応じて除外設定を追加
+   - **重要**: pre-commit関連のコミットを取り込む前に、必ずこの設定を確認
+
+### フェーズ1: 最初のバグ修正・機能改善（58dd14767直後）
+
+**58dd14767以降の最初のコミット群**（時系列順）:
+
+1. **`6eb2612f2`** - build PRs against try branches
+2. **`4c8a20136`** - winUser.WinTimer: ensure timerFunc is correctly wrapped as a TIMERPROC even when None. (#18925)
+3. **`e1cef0775`** - Support image descriptions using local AI model (#18475)
+4. **`2f8a9df9d`** - Replace remaining raw ctypes calls to hid.dll with winBindings.hid definitions. (#18902)
+5. **`47e6cf5da`** - Move all remaining kernel32 ctypes calls to winBindings (#18896)
+6. **`edc18bdd3`** - Shorten indentation beeps (#18898)
+7. **`96325a9dc`** - Moving mouse with audio coordinates no longer throws an error (#18931)
+8. **`937891efd`** - systemUtils.ExecAndPump: the thread handle passed to msgWaitForMultipleObjects should be a proper HANDLE not c_int. (#18927)
+9. **`6009312ad`** - Replace some internal deprecated usage with correct symbols (#18930)
+10. **`ddaa02591`** - change button shown after a successful download from 'Yes' to 'OK' (#18934)
+
+**方針**:
+- 小さなグループ（5-10コミット）に分けて取り込む
+- 各グループで検証（ビルド・型チェック・単体テスト）
+
+### フェーズ2: 依存関係・ビルドシステムの更新
+
+1. **依存関係の更新**（カテゴリ5）
+   - `17ed5ef7c` - Updated Python 3.13.9 to 3.13.11 (#19352)
+   - `250802a27` - Update dependencies for 2026.1 (#19196)
+   - `e6a466a5a` - Update eSpeak NG and Unicode CLDR (#19293)
+   - `33cf7ad75` - Remove SAPI4 (#19290)
+
+### フェーズ3: バグ修正・機能改善の継続
+
+1. **バグ修正の取り込み**（カテゴリ2）
+   - 軽微なバグ修正から開始
+   - 各変更後に検証
+
+### フェーズ4: 機能追加
+
+1. **機能追加の取り込み**（カテゴリ3）
+   - 小さな機能追加から開始
+
+2. **大規模な変更の検討**（カテゴリ7）
+   - MathCAT統合など、大規模な変更は別途検討
+
+### フェーズ5: pre-commit関連（最後に）
+
+1. **pre-commit関連の取り込み**（カテゴリ6）
+   - `d5558c902` - Pre-commit auto-update (#19162)
+   - `9616ef6b1` - Pre-commit auto-fix
+   - `ac00ae465` - minor format fixups
+   - **重要**: 日本語ドキュメントの保護を確認してから取り込む
+   - フォーマット修正のコミットを取り込んだ後、日本語ドキュメントが変更されていないか確認
+
+### フェーズ5: 翻訳・ドキュメント（必要に応じて）
+
+1. **翻訳関連**（カテゴリ1）
+   - 日本語版では `jptools/nvda-jp-patch.po` を使用しているため、スキップするか、JP固有翻訳をマージ
+
+2. **ドキュメント更新**（カテゴリ4）
+   - 必要に応じて取り込む
+
+## 注意事項
+
+1. **小さなPR単位で進める**: 1つのPRで5-10コミット程度を目安
+2. **各変更後に検証**: ビルド・型チェック・単体テストを実行
+3. **日本語ドキュメントの保護**: pre-commitフォーマット修正のコミットを取り込む際は、特に注意
+4. **JP固有コードの維持**: JP PATCHマーカーを追加し、差分最小化の原則に従う
+
+## 次のステップ
+
+1. **フェーズ1の実施**: pre-commit設定の確認
+2. **フェーズ2の実施**: 小さな変更から段階的に取り込み
+3. **各フェーズでの検証**: ビルド・型チェック・単体テストを実行

--- a/projectDocs/jp/task3b4-implementation-plan.md
+++ b/projectDocs/jp/task3b4-implementation-plan.md
@@ -1,0 +1,342 @@
+# タスク 3b.4: x64移行後の変更の取り込み実施計画
+
+**作成日時**: 2026-01-07  
+**対象ブランチ**: `alphajp-260107`  
+**参照**: `projectDocs/jp/roadmap.md:137-150`
+
+## 目的
+
+本家（nvaccess/beta）の x64移行コミット（`58dd14767`）以降の変更を段階的に取り込み、最新のbetaまでの変更を統合する。
+
+## 前提条件
+
+### ✅ 完了済み
+
+* ✅ **x64移行完了**: コミット `58dd14767` (2025年9月15日) "Only build 64bit" をマージ完了
+* ✅ **リグレッション対策**: 2025.3.x jp との機能比較と機能復元（コード比較で判断可能な範囲）完了
+* ✅ **ユニットテスト**: すべて通過（951テスト、5スキップ）
+
+### ⚠️ 確認が必要な項目
+
+* [ ] **pre-commit設定の確認**: 日本語ドキュメント（`projectDocs/jp/`、`readme-nvdajp.md`、`AGENTS.md`）が pre-commit フックから除外されていることを確認
+* [ ] **本家の最新状態**: nvaccess/beta の最新コミットを確認
+* [ ] **マージ範囲**: `58dd14767` 以降のコミット数を確認
+
+## 参照ドキュメントの教訓
+
+### `period2-qa-evaluation.md` からの教訓
+
+1. **改行コードの変更を避ける**: 改行コードの変更が何度も繰り返されないようにする
+2. **コミットをまとめる**: 関連する変更は1つのコミットにまとめる
+3. **フォーマット修正は1つのコミットに**: trailing whitespace、trailing comma、end of file を一度に修正
+
+### `period2-scope-separation-plan.md` からの教訓
+
+1. **スコープの明確化**: 機能実装とフォーマット修正を分離
+2. **日本語ドキュメントの保護**: pre-commit設定で除外する
+3. **段階的な検証**: 各変更後にビルド・型チェック・単体テストを実行
+
+### `period2-implementation-strategy.md` からの教訓
+
+1. **安全性を優先**: 履歴を残し、force pushを避ける
+2. **PRでレビュー**: 小さなPR単位で進める
+3. **柔軟性**: 問題が発生した場合、元のブランチに戻れる
+
+## 実施計画
+
+### フェーズ0: 準備作業（最優先）
+
+#### タスク 0.1: pre-commit設定の確認と更新
+
+**目的**: 日本語ドキュメントをpre-commitフックから保護する
+
+**作業内容**:
+
+1. **現在の設定を確認**
+   ```powershell
+   # .pre-commit-config.yaml を確認
+   Get-Content .pre-commit-config.yaml | Select-String -Pattern "projectDocs/jp|readme-nvdajp|AGENTS"
+   ```
+
+2. **除外設定の追加**（必要に応じて）
+   - `trailing-whitespace` から `projectDocs/jp/`、`readme-nvdajp.md`、`AGENTS.md` を除外
+   - `end-of-file-fixer` から `projectDocs/jp/`、`readme-nvdajp.md`、`AGENTS.md` を除外
+   - `ruff` から `miscDepsJp/include` を除外（既に設定されているか確認）
+
+3. **検証**
+   - ビルド・型チェック・単体テストを実行
+   - CIが通過することを確認
+
+**参照**: `projectDocs/jp/period2-implementation-strategy.md` の「グループ1: pre-commit設定の除外」
+
+#### タスク 0.2: 本家の最新状態の確認（完了）
+
+✅ **完了**: nvaccess/beta の最新コミットを確認済み
+- 最新コミット: `d10ade5d9` (Update tracked translations from Crowdin #19415)
+- 取り込むべきコミット数: 約50コミット（72c211456..nvaccess/beta）
+- 詳細は `projectDocs/jp/task3b4-commits-to-merge.md` を参照
+
+### フェーズ1: 最初のバグ修正・機能改善（58dd14767直後）
+
+**目的**: 取り込むべき変更の範囲を確認する
+
+**作業内容**:
+
+1. **リモートの追加**（必要に応じて）
+   ```powershell
+   git remote add nvaccess https://github.com/nvaccess/nvda.git
+   git fetch nvaccess beta
+   ```
+
+2. **コミット範囲の確認**
+   ```powershell
+   # x64移行後のコミット数を確認
+   git log --oneline nvaccess/beta --not 58dd14767 | Measure-Object -Line
+   
+   # 最新のコミットを確認
+   git log --oneline nvaccess/beta -1
+   ```
+
+3. **pre-commitフォーマット修正のコミットを確認**
+   ```powershell
+   # pre-commit関連のコミットを確認
+   git log --oneline nvaccess/beta --not 58dd14767 | Select-String -Pattern "pre-commit|format|trailing|whitespace"
+   ```
+
+**成果物**:
+- 取り込むべきコミット数のリスト
+- pre-commitフォーマット修正のコミットの特定
+
+#### タスク 1.1: 最初のバグ修正・機能改善の取り込み
+
+**目的**: 58dd14767以降の最初のコミット群を取り込む
+
+**対象コミット**（時系列順）:
+- `6eb2612f2` - build PRs against try branches
+- `4c8a20136` - winUser.WinTimer: ensure timerFunc is correctly wrapped as a TIMERPROC even when None. (#18925)
+- `e1cef0775` - Support image descriptions using local AI model (#18475)
+- `2f8a9df9d` - Replace remaining raw ctypes calls to hid.dll with winBindings.hid definitions. (#18902)
+- `47e6cf5da` - Move all remaining kernel32 ctypes calls to winBindings (#18896)
+- その他、最初の10-20コミット程度
+
+**作業内容**:
+1. 小さなグループ（5-10コミット）に分ける
+2. 各グループをマージ
+3. コンフリクトの解決
+4. 検証（ビルド・型チェック・単体テスト）
+
+### フェーズ2: 依存関係・ビルドシステムの更新
+
+#### タスク 2.1: 依存関係の更新
+
+**目的**: マージプロセスを検証し、問題がないことを確認する
+
+**作業内容**:
+
+1. **小さな変更を選択**
+   - バグ修正や軽微な変更から開始
+   - pre-commitフォーマット修正は除外
+
+2. **マージの実施**
+   ```powershell
+   # 特定のコミットをマージ
+   git merge --no-ff <commit-hash>
+   ```
+
+3. **検証**
+   - ビルド: `scons source --all-cores`
+   - 型チェック: `ci/scripts/tests/typeCheck.ps1`
+   - 単体テスト: `.\rununittests.bat`
+   - JP smoke tests: `.\jptools\runJpSmokeTests.ps1`
+
+4. **問題があれば修正**
+   - コンフリクトの解決
+   - JP固有コードの維持
+   - JP PATCHマーカーの追加
+
+**完了条件**:
+- すべてのテストが通過
+- CIが通過することを確認
+
+### フェーズ3: バグ修正・機能改善の継続
+
+#### タスク 3.1: バグ修正の取り込み
+
+**目的**: カテゴリ2のバグ修正を段階的に取り込む
+
+**作業内容**:
+1. 小さなグループに分ける
+2. 各グループでマージと検証
+
+### フェーズ4: 機能追加
+
+#### タスク 4.1: 機能追加の取り込み
+
+**目的**: カテゴリ3の機能追加を段階的に取り込む
+
+### フェーズ5: pre-commit関連（最後に）
+
+#### タスク 5.1: pre-commitフォーマット修正の取り込み（注意が必要）
+
+**目的**: pre-commitによる大規模なファイルフォーマット自動整形のコミットを取り込む
+
+**作業内容**:
+
+1. **フォーマット修正のコミットを特定**
+   - pre-commit関連のコミットを確認
+   - フォーマット修正のみのコミットを特定
+
+2. **日本語ドキュメントの保護確認**
+   - `.pre-commit-config.yaml` で除外設定が有効か確認
+   - 必要に応じて除外設定を追加
+
+3. **フォーマット修正の取り込み**
+   ```powershell
+   # フォーマット修正のコミットをマージ
+   git merge --no-ff <format-commit-hash>
+   ```
+
+4. **日本語ドキュメントの確認**
+   - `projectDocs/jp/` 配下のファイルが変更されていないか確認
+   - `readme-nvdajp.md`、`AGENTS.md` が変更されていないか確認
+   - 変更されていた場合は、元に戻す
+
+5. **検証**
+   - ビルド・型チェック・単体テストを実行
+   - CIが通過することを確認
+
+**注意事項**:
+- フォーマット修正は1つのコミットにまとめる
+- 日本語ドキュメントが変更されていないことを必ず確認
+- 変更されていた場合は、即座に元に戻す
+
+**参照**: `projectDocs/jp/period2-qa-evaluation.md` の「フォーマット修正が複数のコミットに分かれている」問題を避ける
+
+#### タスク 2.3: 機能追加・バグ修正の取り込み
+
+**目的**: 本家の機能追加・バグ修正を段階的に取り込む
+
+**作業内容**:
+
+1. **変更の分類**
+   - 機能追加
+   - バグ修正
+   - リファクタリング
+   - ドキュメント更新
+
+2. **小さなグループに分ける**
+   - 関連する変更をまとめる
+   - 1つのPRで5-10コミット程度を目安
+
+3. **各グループでのマージと検証**
+   - マージの実施
+   - コンフリクトの解決
+   - 検証（ビルド・型チェック・単体テスト）
+   - CIが通過することを確認
+
+4. **JP固有コードの維持**
+   - JP PATCHマーカーを追加
+   - 差分最小化の原則に従う
+
+**完了条件**:
+- すべてのテストが通過
+- CIが通過することを確認
+- JP固有機能が保持されている
+
+### フェーズ3: 完了確認
+
+#### タスク 3.1: 最終検証
+
+**目的**: すべての変更が正常に取り込まれていることを確認する
+
+**作業内容**:
+
+1. **ビルドの確認**
+   ```powershell
+   scons source --all-cores
+   ```
+
+2. **型チェックの確認**
+   ```powershell
+   ci/scripts/tests/typeCheck.ps1
+   ```
+
+3. **単体テストの確認**
+   ```powershell
+   .\rununittests.bat
+   ```
+
+4. **JP smoke testsの確認**
+   ```powershell
+   .\jptools\runJpSmokeTests.ps1
+   ```
+
+5. **CIの確認**
+   - PRを作成してCIが通過することを確認
+
+**完了条件**:
+- すべてのテストが通過
+- CIが通過することを確認
+- 本家の最新状態（`1cee6d93c` または最新）まで取り込み完了
+
+## 品質保証原則の遵守
+
+### 小さなPR単位で進める
+
+- 1つのPRで5-10コミット程度を目安
+- 関連する変更をまとめる
+- 各PRで全テスト通過を確認
+
+### 段階的な検証を必須とする
+
+- 各変更後にビルド・型チェック・単体テストを実行
+- CIが通過することを確認
+- 問題があれば即座に停止
+
+### 完了の定義を明確化
+
+- テストが全て通過し、CIが安定して緑になるまで「完了」としない
+- 本家の最新状態まで取り込み完了
+
+### 問題が発生したら即座に停止
+
+- テスト失敗や不安定な動作が見られたら、次の段階に進まずに問題を解決
+- 必要に応じて、変更をリバート
+
+## リスクと対策
+
+### リスク1: pre-commitフォーマット修正による日本語ドキュメントの破壊
+
+**対策**:
+- 事前にpre-commit設定で除外設定を確認・追加
+- フォーマット修正の取り込み後に、日本語ドキュメントが変更されていないか確認
+- 変更されていた場合は、即座に元に戻す
+
+### リスク2: 大規模な変更によるコンフリクト
+
+**対策**:
+- 小さなグループに分けて段階的に取り込む
+- 各変更後に検証を実施
+- 問題があれば即座に停止
+
+### リスク3: JP固有機能の失われ
+
+**対策**:
+- 各変更後にJP固有機能が保持されているか確認
+- JP PATCHマーカーを追加
+- 差分最小化の原則に従う
+
+## 次のステップ
+
+1. **フェーズ1の実施**: pre-commit設定の確認と本家の最新状態の確認
+2. **フェーズ2の実施**: 段階的な変更の取り込み
+3. **フェーズ3の実施**: 完了確認
+
+## 参考資料
+
+- **ロードマップ**: `projectDocs/jp/roadmap.md`
+- **期間2の品質保証評価**: `projectDocs/jp/period2-qa-evaluation.md`
+- **期間2のスコープ分割計画**: `projectDocs/jp/period2-scope-separation-plan.md`
+- **期間2の実装戦略**: `projectDocs/jp/period2-implementation-strategy.md`
+- **ステージ3b移行計画**: `projectDocs/jp/stage3b-x64-migration-plan.md`
+- **AGENTS.md**: 差分最小化の原則、JP PATCHマーカーの使用規則

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -6,6 +6,7 @@
 # See the file COPYING for more details.
 
 import ctypes
+import textInfos
 import textInfos.offsets
 import winKernel
 import winUser
@@ -312,6 +313,19 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 			else:
 				tempOffset -= 1
 		return [start, end]
+
+	# BEGIN JP PATCH
+	# nvdajp: Fix for issue #17430 - Notepad++ braille line navigation
+	def collapse(self, end: bool = False):
+		"""Before collapsing to end, if no text is selected, TextInfo is expanded to line.
+		This fixes a bug where next braille line command didn't move the cursor to the last empty line
+		in Notepad++ documents.
+		https://github.com/nvaccess/nvda/issues/17430
+		"""
+		if end and self.obj.makeTextInfo(textInfos.POSITION_SELECTION).isCollapsed:
+			self.expand(textInfos.UNIT_LINE)
+		super().collapse(end=end)
+	# END JP PATCH
 
 
 # The Scintilla NVDA object, inherists the generic MSAA NVDA object

--- a/source/api.py
+++ b/source/api.py
@@ -98,7 +98,7 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 	# add the old focus to the old focus ancestors, but only if its not None (is none at NVDA initialization)
 	if globalVars.focusObject:
 		oldFocusLine.append(globalVars.focusObject)
-	oldAppModules = [o.appModule for o in oldFocusLine if o and o.appModule]
+	oldAppModules = [o.appModule for o in oldFocusLine if o and getattr(o, "appModule", None)]
 	appModuleHandler.cleanup()
 	ancestors = []
 	tempObj = obj
@@ -150,14 +150,18 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 			break
 		# We're moving backwards along the ancestor chain, so add this to the start of the list.
 		ancestors.insert(0, tempObj)
-		container = tempObj.container
-		tempObj.container = container  # Cache the parent.
-		tempObj = container
+		# BEGIN JP PATCH
+		# nvdajp: Keep hasattr check for safety
+		if hasattr(tempObj, "container"):
+			container = tempObj.container
+			tempObj.container = container  # Cache the parent.
+		tempObj = container if hasattr(tempObj, "container") else None
+		# END JP PATCH
 	# Remove the final new ancestor as this will be the new focus object
 	del ancestors[-1]
 	# #5467: Ensure that the appModule of the real focus is included in the newAppModule list for profile switching
 	# Rather than an original focus ancestor which happened to match the new focus.
-	newAppModules = [o.appModule for o in ancestors if o and o.appModule]
+	newAppModules = [o.appModule for o in ancestors if o and getattr(o, "appModule", None)]
 	if obj.appModule:
 		newAppModules.append(obj.appModule)
 	try:

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -177,7 +177,11 @@ class AutoPropertyObject(garbageHandler.TrackedObject, metaclass=AutoPropertyTyp
 		# We use a list here, as invalidating the cache on an object may cause instances to disappear,
 		# which would in turn cause an exception due to the dictionary changing size during iteration.
 		for instance in list(cls.__instances):
-			instance.invalidateCache()
+			# BEGIN JP PATCH
+			# nvdajp: Keep hasattr check for safety
+			if hasattr(instance, "invalidateCache"):
+				instance.invalidateCache()
+			# END JP PATCH
 
 
 class ScriptableType(AutoPropertyType):


### PR DESCRIPTION
本家 2026.1 の日本語版へのマージに伴い、2025.3jp で正しい実装として受け入れられていた JP 固有コードを復活する作業。

#620 の作業を再確認。