### PR TITLE
Update beta-merge-strategy.md and sync submodules with nvaccess/beta

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -268,9 +268,12 @@ env.Command(
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, iSimpleDomRPCStubs[1])  # typelib
 
-mathPlayerRPCStubs = env.SConscript("mathPlayer_sconscript")
-if isNVDACoreArch:
-	env.Install(sourceTypelibDir, mathPlayerRPCStubs[0])  # typelib
+# BEGIN JP PATCH
+# mathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
+# mathPlayerRPCStubs = env.SConscript("mathPlayer_sconscript")
+# if isNVDACoreArch:
+# 	env.Install(sourceTypelibDir, mathPlayerRPCStubs[0])  # typelib
+# END JP PATCH
 
 detoursLib = env.SConscript("detours/sconscript")
 Export("detoursLib")

--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -268,13 +268,6 @@ env.Command(
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, iSimpleDomRPCStubs[1])  # typelib
 
-# BEGIN JP PATCH
-# mathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
-# mathPlayerRPCStubs = env.SConscript("mathPlayer_sconscript")
-# if isNVDACoreArch:
-# 	env.Install(sourceTypelibDir, mathPlayerRPCStubs[0])  # typelib
-# END JP PATCH
-
 detoursLib = env.SConscript("detours/sconscript")
 Export("detoursLib")
 

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -136,6 +136,7 @@ comtypes.client.gen_dir = Dir("comInterfaces").abspath
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
+	"Scripting.py": ("{420B2830-E718-11CF-893D-00AA00389B71}", 1, 0),  # Used for browseable messages
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),
 	"SpeechLib.py": ("{C866CA3A-32F7-11D2-9602-00C04F8EE628}", 5, 0),

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -137,7 +137,10 @@ COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
 	"Scripting.py": ("{420B2830-E718-11CF-893D-00A0C9054228}", 1, 0),  # Used for browseable messages
-	"MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
+	# BEGIN JP PATCH
+	# MathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
+	# "MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
+	# END JP PATCH
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),
 	"SpeechLib.py": ("{C866CA3A-32F7-11D2-9602-00C04F8EE628}", 5, 0),

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -136,11 +136,6 @@ comtypes.client.gen_dir = Dir("comInterfaces").abspath
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
-	"Scripting.py": ("{420B2830-E718-11CF-893D-00A0C9054228}", 1, 0),  # Used for browseable messages
-	# BEGIN JP PATCH
-	# MathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
-	# "MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
-	# END JP PATCH
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),
 	"SpeechLib.py": ("{C866CA3A-32F7-11D2-9602-00C04F8EE628}", 5, 0),


### PR DESCRIPTION
## 変更内容

- beta-merge-strategy.mdを更新: サブモジュール再同期の手順を削除し、再同期済みを前提として記述を更新
- サブモジュールをnvaccess/betaと同期:
  - \miscDeps\を同期
  - \include/nvda-cldr\を同期

## 関連
- サブモジュール再同期の詳細はroadmap.mdでカバー
- この変更により、beta-merge-strategy.mdはサブモジュール再同期が完了した状態を前提として、ブランチの切り直しとJP固有の変更の再適用に焦点を当てた内容になりました