### PR TITLE
Update beta-merge-strategy.md and sync submodules with nvaccess/beta

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -268,9 +268,12 @@ env.Command(
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, iSimpleDomRPCStubs[1])  # typelib
 
-mathPlayerRPCStubs = env.SConscript("mathPlayer_sconscript")
-if isNVDACoreArch:
-	env.Install(sourceTypelibDir, mathPlayerRPCStubs[0])  # typelib
+# BEGIN JP PATCH
+# mathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
+# mathPlayerRPCStubs = env.SConscript("mathPlayer_sconscript")
+# if isNVDACoreArch:
+# 	env.Install(sourceTypelibDir, mathPlayerRPCStubs[0])  # typelib
+# END JP PATCH
 
 detoursLib = env.SConscript("detours/sconscript")
 Export("detoursLib")

--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -268,13 +268,6 @@ env.Command(
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, iSimpleDomRPCStubs[1])  # typelib
 
-# BEGIN JP PATCH
-# mathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
-# mathPlayerRPCStubs = env.SConscript("mathPlayer_sconscript")
-# if isNVDACoreArch:
-# 	env.Install(sourceTypelibDir, mathPlayerRPCStubs[0])  # typelib
-# END JP PATCH
-
 detoursLib = env.SConscript("detours/sconscript")
 Export("detoursLib")
 

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -136,7 +136,7 @@ comtypes.client.gen_dir = Dir("comInterfaces").abspath
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
-	"Scripting.py": ("{420B2830-E718-11CF-893D-00AA00389B71}", 1, 0),  # Used for browseable messages
+	"Scripting.py": ("{420B2830-E718-11CF-893D-00A0C9054228}", 1, 0),  # Used for browseable messages
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),
 	"SpeechLib.py": ("{C866CA3A-32F7-11D2-9602-00C04F8EE628}", 5, 0),

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -136,6 +136,7 @@ comtypes.client.gen_dir = Dir("comInterfaces").abspath
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
+	"Scripting.py": ("{420B2830-E718-11CF-893D-00AA00389B71}", 1, 0),  # Used for browseable messages
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),
 	"SpeechLib.py": ("{C866CA3A-32F7-11D2-9602-00C04F8EE628}", 5, 0),

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -137,7 +137,10 @@ COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
 	"Scripting.py": ("{420B2830-E718-11CF-893D-00A0C9054228}", 1, 0),  # Used for browseable messages
-	"MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
+	# BEGIN JP PATCH
+	# MathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
+	# "MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
+	# END JP PATCH
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),
 	"SpeechLib.py": ("{C866CA3A-32F7-11D2-9602-00C04F8EE628}", 5, 0),

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -136,11 +136,6 @@ comtypes.client.gen_dir = Dir("comInterfaces").abspath
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
-	"Scripting.py": ("{420B2830-E718-11CF-893D-00A0C9054228}", 1, 0),  # Used for browseable messages
-	# BEGIN JP PATCH
-	# MathPlayer support removed in nvaccess/beta (miscDeps no longer includes mathPlayer)
-	# "MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
-	# END JP PATCH
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),
 	"SpeechLib.py": ("{C866CA3A-32F7-11D2-9602-00C04F8EE628}", 5, 0),


### PR DESCRIPTION
## 変更内容

- `projectDocs/jp/beta-merge-strategy.md` を更新（サブモジュール再同期を前提として記載）
- サブモジュール（`include/nvda-cldr`, `miscDeps`）を nvaccess/beta と同期
- mathPlayer の JP PATCH マーカーを削除（本家の変更を取り込む必要があったため）

## 関連

- サブモジュール再同期は `roadmap.md` でカバー
- `beta-merge-strategy.md` は再同期完了を前提として記載
