### PR TITLE
Refactor MeCab integration in JTalk to improve performance and responsiveness

### DIFF
--- a/projectDocs/jp/issue-114-investigation.md
+++ b/projectDocs/jp/issue-114-investigation.md
@@ -1,0 +1,49 @@
+# Issue #114 調査: 点訳エンジンと JTalk 併用時の性能低下
+
+## 参照
+
+- https://github.com/nvdajp/nvdajp/issues/114
+
+## 現象
+
+JTalk で音声出力中に点字表示を同時に行うと、以下の症状が発生する：
+
+- カーソルキーを連打したときに引っかかるようなもたつき
+- Win+R「ファイル名を指定して実行」で下矢印を押しても、点字表示ありだとスピーチが即座に中断されず、複数回押す必要がある
+- 長い文書の読み上げ時にも発生
+
+## 原因
+
+MeCab（形態素解析）は JTalk（音声）と点訳（点字）の両方で共有されており、スレッドロックで排他制御されていた。
+
+**ロックの保持範囲が過剰だった**：
+
+1. **JTalk**（バックグラウンドスレッド）:  
+   `MecabFeatures()` 作成時にロック取得 → `Mecab_analysis` → `Mecab_correctFeatures` →  
+   **`libjt_synthesis`（音声合成、数秒かかる可能性）** →  
+   `del mf` でロック解放
+
+2. **点訳**（メインスレッド）:  
+   フォーカス移動などで点字更新 → `louisHelper.translate` → `translator2` →  
+   `MecabFeatures()` でロック取得を待機
+
+**結果**：JTalk が音声合成中にロックを保持している間、点字更新（メインスレッド）がブロックされ、  
+キー入力の処理やスピーチ中断の処理が遅れるため、カーソル連打時の引っかかりやスピーチの中断遅れが発生していた。
+
+## 修正方針
+
+**ロックの保持時間を最小化**：MeCab DLL 呼び出し（`Mecab_analysis`, `Mecab_correctFeatures`）の間のみロックを保持する。
+
+- `mecab_analyze_and_correct()` ヘルパーを追加
+- ロックは `Mecab_analysis` と `Mecab_correctFeatures` 実行中のみ保持
+- その後の `Mecab_splitFeatures`、`libjt_synthesis`（JTalk）、`mecab_to_morphs`（点訳）はロック外で実行
+
+## 修正箇所
+
+- `source/synthDrivers/jtalk/mecab.py`: `mecab_analyze_and_correct()` 追加
+- `source/synthDrivers/jtalk/jtalkDriver.py`: 上記ヘルパーを使用
+- `source/synthDrivers/jtalk/translator2.py`: 上記ヘルパーを使用
+
+## ブランチ
+
+`fix-issue-114-mecab-lock`

--- a/source/synthDrivers/jtalk/jtalkDriver.py
+++ b/source/synthDrivers/jtalk/jtalkDriver.py
@@ -30,12 +30,11 @@ from .jtalkCore import (  # noqa: E402
 from .mecab import (  # noqa: E402
 	mecab,
 	Mecab_analysis,
-	Mecab_correctFeatures,
 	Mecab_initialize,
-	MecabFeatures,
 	Mecab_print,
 	Mecab_splitFeatures,
 	Mecab_utf8_to_cp932,
+	mecab_analyze_and_correct,
 )
 from .text2mecab import text2mecab  # noqa: E402
 from . import jtalkPrepare  # noqa: E402
@@ -187,11 +186,7 @@ def _jtalk_speak(msg: str, index: int | None = None, prop: Any = None) -> None:
 		if not isSpeaking():
 			libjt_refresh()
 			return
-		mf = MecabFeatures()
-		Mecab_analysis(s, mf, logwrite_=logwrite)
-		if DEBUG:
-			Mecab_print(mf, logwrite)
-		Mecab_correctFeatures(mf)
+		mf = mecab_analyze_and_correct(s, logwrite_=logwrite)
 		if DEBUG:
 			Mecab_print(mf, logwrite)
 		ar = Mecab_splitFeatures(mf, CODE_="utf-8")

--- a/source/synthDrivers/jtalk/jtalkDriver.py
+++ b/source/synthDrivers/jtalk/jtalkDriver.py
@@ -29,7 +29,6 @@ from .jtalkCore import (  # noqa: E402
 )
 from .mecab import (  # noqa: E402
 	mecab,
-	Mecab_analysis,
 	Mecab_initialize,
 	Mecab_print,
 	Mecab_splitFeatures,

--- a/source/synthDrivers/jtalk/mecab.py
+++ b/source/synthDrivers/jtalk/mecab.py
@@ -176,6 +176,28 @@ class MecabFeatures(NonblockingMecabFeatures):
 		lock.release()
 
 
+def mecab_analyze_and_correct(
+	src: bytes, logwrite_: LogWriteFunc = None
+) -> NonblockingMecabFeatures:
+	"""Run Mecab_analysis and Mecab_correctFeatures with minimal lock duration.
+
+	nvdajp/nvdajp#114: When JTalk (speech) and braille display both use MeCab,
+	they contend on a single lock. Previously MecabFeatures held the lock for
+	its entire lifetime including during libjt_synthesis (which can take seconds).
+	This blocked braille updates on the main thread, causing lag and unresponsive
+	speech cancellation when pressing cursor keys rapidly.
+
+	This helper holds the lock only during the actual MeCab DLL calls. Callers
+	can then process the returned features (Mecab_splitFeatures, mecab_to_morphs,
+	libjt_synthesis, etc.) without blocking other MeCab consumers.
+	"""
+	mf = NonblockingMecabFeatures()
+	with lock:
+		Mecab_analysis(src, mf, logwrite_=logwrite_)
+		Mecab_correctFeatures(mf)
+	return mf
+
+
 def Mecab_initialize(
 	logwrite_: LogWriteFunc = None,
 	libmecab_dir: str | Path | None = None,

--- a/source/synthDrivers/jtalk/translator2.py
+++ b/source/synthDrivers/jtalk/translator2.py
@@ -15,11 +15,10 @@ try:
 	from ._nvdajp_unicode import unicode_normalize
 	from .mecab import (
 		CODE,
-		MecabFeatures,
-		Mecab_analysis,
-		Mecab_correctFeatures,
 		Mecab_initialize,
 		Mecab_print,
+		NonblockingMecabFeatures,
+		mecab_analyze_and_correct,
 	)
 	from .text2mecab import text2mecab
 	from . import translator1
@@ -28,11 +27,10 @@ except (ImportError, ValueError):
 	from _nvdajp_unicode import unicode_normalize  # type: ignore
 	from mecab import (  # type: ignore
 		CODE,
-		MecabFeatures,
-		Mecab_analysis,
-		Mecab_correctFeatures,
 		Mecab_initialize,
 		Mecab_print,
+		NonblockingMecabFeatures,
+		mecab_analyze_and_correct,
 	)
 	from text2mecab import text2mecab  # type: ignore
 	import translator1  # type: ignore
@@ -232,7 +230,7 @@ def update_phonetic_symbols(mo: MecabMorph) -> None:
 			mo.output = mo.output[:p] + mo.kana[p] + mo.output[p + 1 :]
 
 
-def mecab_to_morphs(mf: MecabFeatures | None) -> list[MecabMorph]:
+def mecab_to_morphs(mf: NonblockingMecabFeatures | None) -> list[MecabMorph]:
 	li: list[MecabMorph] = []
 	if mf is None or mf.feature is None or mf.size is None:
 		return li
@@ -1429,9 +1427,7 @@ def japanese_braille_separate(inbuf, logwrite, nabcc=False, use_foreign_quotes=F
 		if logwrite:
 			logwrite("translator2: consecutive ASCII spaces detected")
 	text = text2mecab(text)
-	mf = MecabFeatures()
-	Mecab_analysis(text, mf, logwrite_=logwrite)
-	Mecab_correctFeatures(mf)
+	mf = mecab_analyze_and_correct(text, logwrite_=logwrite)
 	Mecab_print(mf, logwrite, output_header=False)
 	li = mecab_to_morphs(mf)
 	mf = None


### PR DESCRIPTION
https://github.com/nvdajp/nvdajp/issues/114

- Introduced a new helper function `mecab_analyze_and_correct` to streamline the analysis and correction of MeCab features, reducing lock duration and preventing lag during speech synthesis.
- Updated references in `jtalkDriver.py` and `translator2.py` to utilize the new function, enhancing the efficiency of MeCab feature processing.
- Changed type annotations from `MecabFeatures` to `NonblockingMecabFeatures` to reflect the updated implementation.

