### PR TITLE
Suppress KGS connection beeps during install (#470)

### DIFF
--- a/jptools/kgs_bdDetect_probe.py
+++ b/jptools/kgs_bdDetect_probe.py
@@ -2,22 +2,145 @@
 
 Usage:
   py jptools/kgs_bdDetect_probe.py
+  py jptools/kgs_bdDetect_probe.py --encoding mbcs
+  py jptools/kgs_bdDetect_probe.py --encoding auto
+
+Encoding:
+  Japanese Windows consoles often use the system ANSI code page (MBCS, typically cp932).
+  PowerShell may emit UTF-8 or MBCS depending on version and settings. Use --encoding
+  mbcs if device names look garbled with the default, or set KGS_PROBE_ENCODING=mbcs.
 """
 
 from __future__ import annotations
 
+import argparse
 import itertools
 import json
+import locale
 import os
 import re
 import subprocess
 import sys
 import winreg
 
+_ENCODING_CHOICES = ("auto", "utf-8", "mbcs")
+_OUTPUT_ENCODING: str = "utf-8"
+_SUBPROCESS_DECODINGS: list[str] = ["utf-8-sig", "utf-8", "mbcs"]
+
+
+def _encoding_candidates() -> list[str]:
+	"""Build an ordered list of encodings to try for subprocess output."""
+	candidates: list[str] = []
+	if override := os.environ.get("KGS_PROBE_ENCODING"):
+		candidates.append(override.strip())
+	if _OUTPUT_ENCODING not in ("auto",):
+		candidates.append(_OUTPUT_ENCODING)
+	if sys.stdout.encoding:
+		candidates.append(sys.stdout.encoding)
+	try:
+		candidates.append(locale.getencoding())
+	except AttributeError:
+		candidates.append(locale.getpreferredencoding(False))
+	candidates.extend(_SUBPROCESS_DECODINGS)
+	seen: set[str] = set()
+	ordered: list[str] = []
+	for enc in candidates:
+		if not enc or enc in seen:
+			continue
+		seen.add(enc)
+		ordered.append(enc)
+	return ordered
+
+
+def _resolve_output_encoding(name: str) -> str:
+	"""Resolve CLI --encoding for stdout."""
+	if name != "auto":
+		return name
+	if os.environ.get("PYTHONUTF8", "").lower() in ("1", "true", "yes"):
+		return "utf-8"
+	stdout_enc = (sys.stdout.encoding or "").lower().replace("-", "")
+	if stdout_enc in ("utf8", "utf_8"):
+		return "utf-8"
+	if sys.platform == "win32":
+		try:
+			return locale.getencoding() or "mbcs"
+		except AttributeError:
+			return locale.getpreferredencoding(False) or "mbcs"
+	return sys.stdout.encoding or "utf-8"
+
+
+def _text_decode_score(text: str) -> int:
+	"""Heuristic: higher is more likely correct Japanese/ASCII device text."""
+	if not text:
+		return -999
+	score = 0
+	if "\ufffd" in text:
+		score -= 100
+	if "Bluetooth" in text:
+		score += 5
+	if any("\u3040" <= c <= "\u30ff" or "\u4e00" <= c <= "\u9fff" for c in text):
+		score += 25
+	# Typical mojibake when UTF-8 is read as MBCS (or the reverse)
+	score -= sum(1 for c in text if "\u0080" <= c <= "\u00ff")
+	return score
+
+
+def _json_caption_score(decoded: str) -> int:
+	"""Score a decoded JSON blob by PnP Caption fields (if parseable)."""
+	try:
+		data = json.loads(decoded.strip())
+	except json.JSONDecodeError:
+		return _text_decode_score(decoded)
+	if isinstance(data, dict):
+		items = [data]
+	elif isinstance(data, list):
+		items = data
+	else:
+		return _text_decode_score(decoded)
+	score = 0
+	for item in items:
+		if isinstance(item, dict):
+			score = max(score, _text_decode_score(str(item.get("Caption") or "")))
+	return score
+
+
+def _decode_bytes(data: bytes, encodings: list[str] | None = None) -> tuple[str, str]:
+	"""Decode subprocess bytes; return (text, encoding_used)."""
+	candidates = encodings or _encoding_candidates()
+	if len(candidates) == 1:
+		enc = candidates[0]
+		try:
+			return data.decode(enc), enc
+		except (LookupError, UnicodeDecodeError):
+			return data.decode("utf-8", errors="replace"), "utf-8(replace)"
+
+	best_text = ""
+	best_enc = "utf-8(replace)"
+	best_score = -10**9
+	for enc in candidates:
+		try:
+			text = data.decode(enc)
+		except (LookupError, UnicodeDecodeError):
+			continue
+		score = _json_caption_score(text)
+		if score > best_score:
+			best_score = score
+			best_text = text
+			best_enc = enc
+	if best_text:
+		return best_text, best_enc
+	return data.decode("utf-8", errors="replace"), "utf-8(replace)"
+
 
 def _out(text: str) -> None:
-	enc = sys.stdout.encoding or "utf-8"
-	print(text.encode(enc, errors="replace").decode(enc, errors="replace"))
+	"""Print using the resolved console encoding (avoids double codec on Windows)."""
+	payload = (text + os.linesep).encode(_OUTPUT_ENCODING, errors="replace")
+	try:
+		sys.stdout.buffer.write(payload)
+		sys.stdout.buffer.flush()
+	except (AttributeError, OSError):
+		print(text)
+
 
 _KGS_USB_IDS = (
 	"VID_1148&PID_0301",
@@ -73,8 +196,10 @@ def _usb_id_from_pnp_id(pnp_id: str) -> str | None:
 	return m.group(0) if m else None
 
 
-def _live_ports_pnp() -> list[dict]:
-	"""Serial/COM devices via PowerShell (no NVDA imports)."""
+def _live_ports_pnp() -> tuple[list[dict], str]:
+	"""Serial/COM devices via PowerShell (no NVDA imports). Returns rows and decode label."""
+	# Do not force PowerShell output encoding: on Japanese Windows the pipeline may be
+	# UTF-8 or MBCS (cp932); _decode_bytes picks the best match.
 	ps = (
 		"$ports = @(); "
 		"Get-CimInstance Win32_PnPEntity | Where-Object { $_.Caption -match '\\(COM\\d+\\)' } | "
@@ -85,18 +210,17 @@ def _live_ports_pnp() -> list[dict]:
 		"$ports | ConvertTo-Json -Compress"
 	)
 	try:
-		out = subprocess.check_output(
+		raw = subprocess.check_output(
 			["powershell", "-NoProfile", "-Command", ps],
-			text=True,
-			encoding="utf-8",
-			errors="replace",
 			timeout=30,
-		).strip()
+		)
 	except (subprocess.SubprocessError, OSError) as ex:
 		_out("  (PnP query failed: %s)" % ex)
-		return []
+		return [], "n/a"
+	text, decode_used = _decode_bytes(raw)
+	out = text.strip()
 	if not out or out == "null":
-		return []
+		return [], decode_used
 	data = json.loads(out)
 	if isinstance(data, dict):
 		data = [data]
@@ -116,11 +240,37 @@ def _live_ports_pnp() -> list[dict]:
 				"isBluetooth": "BTHENUM" in pnp.upper() or "BTHMODEM" in pnp.upper(),
 			},
 		)
-	return rows
+	return rows, decode_used
+
+
+def _parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser(description="Probe USB/COM data for KGS bdDetect.")
+	parser.add_argument(
+		"--encoding",
+		choices=_ENCODING_CHOICES,
+		default="auto",
+		help=(
+			"Console output encoding and preferred subprocess decode "
+			"(auto: system locale / MBCS on Japanese Windows; mbcs: ANSI code page)"
+		),
+	)
+	return parser.parse_args()
 
 
 def main() -> int:
-	_out("KGS bdDetect probe\n=== Registry USB -> COM (can remain after unplug) ===")
+	global _OUTPUT_ENCODING, _SUBPROCESS_DECODINGS
+
+	args = _parse_args()
+	_OUTPUT_ENCODING = _resolve_output_encoding(args.encoding)
+	if args.encoding == "mbcs":
+		_SUBPROCESS_DECODINGS = ["mbcs", "cp932", "utf-8-sig", "utf-8"]
+	elif args.encoding == "utf-8":
+		_SUBPROCESS_DECODINGS = ["utf-8-sig", "utf-8", "mbcs"]
+	else:
+		_SUBPROCESS_DECODINGS = ["utf-8-sig", "utf-8", "mbcs", "cp932"]
+
+	_out("KGS bdDetect probe (stdout encoding: %s)" % _OUTPUT_ENCODING)
+	_out("=== Registry USB -> COM (can remain after unplug) ===")
 	registry_coms: dict[str, list[str]] = {}
 	for vidPid in _KGS_USB_IDS:
 		for e in _enum_usb_com_ports(vidPid):
@@ -137,7 +287,8 @@ def main() -> int:
 		_out("  %s <= %s" % (e["port"], e["device"]))
 
 	_out("\n=== Live PnP serial (Name / usbID / Status) ===")
-	live = _live_ports_pnp()
+	live, pnp_decode = _live_ports_pnp()
+	_out("  (PnP JSON decoded as: %s)" % pnp_decode)
 	if not live:
 		_out("  (none or query failed)")
 	for row in live:

--- a/projectDocs/jp/kgsbraille.md
+++ b/projectDocs/jp/kgsbraille.md
@@ -110,7 +110,7 @@ KGS 系は **2011 年頃から**（著作権表記: Shinke / Misono / Nishimoto�
 **KGS の現状**
 
 - 3 ドライバとも **`supportedSettings` 未宣言**（実質オプションなし）
-- 接続速度（9600 bps 固定）、KBDC 名（`Active BM` / Shift-JIS 機種名）、ビープによる接続フィードバックなどは **すべてコード固定**
+- 接続速度（9600 bps 固定）、KBDC 名（`Active BM` / Shift-JIS 機種名）、ビープによる接続フィードバックなどは **すべてコード固定**（接続プローブ音のインストール時抑制は [§2.6](#26-接続プローブ音とインストールランチャー時の抑制470)）
 - ユーザーが NVDA 設定だけで変えられる項目は **ポート選択と gestureMap（NVDA キー割当）** が中心
 
 **メンテナンス上の意味**
@@ -130,6 +130,65 @@ KGS 系は **2011 年頃から**（著作権表記: Shinke / Misono / Nishimoto�
 
 これらは **ハード・DLL の能力外**として、無理に追従する必要はない。
 
+### 2.6 接続プローブ音とインストール／ランチャー時の抑制（#470）
+
+**背景**
+
+- [nvdajp/nvdajp#470](https://github.com/nvdajp/nvdajp/issues/470): KGS USB ドライバーが入っているが端末がすぐ見つからないとき、NVDA **インストール／ランチャー**起動中に点字自動検出が COM 接続を試行し、`_fixConnection` のプローブ音が **音声の読み上げを遮る**。
+- ランチャー（`--launcher`）のみの段階でも `braille.initialize()` と `bdDetect` は動くため、許諾画面やインストール UI の読み上げと競合しうる（`--install` が付く前から該当）。
+
+**実装（`betajp-kgs-issue470` / PR [#659](https://github.com/nvdajp/nvdajp/pull/659)）**
+
+`kgs.py` に `_connectionBeepsEnabled()` を定義し、次のいずれかが真のとき **接続プローブ用トーンを鳴らさない**。
+
+| フラグ | コマンドライン | 典型的な場面 |
+|--------|----------------|--------------|
+| `globalVars.appArgs.install` | `--install` | コマンドラインからのインストール（完了後に新 NVDA を起動しうる） |
+| `globalVars.appArgs.installSilent` | `--install-silent` | サイレントインストール（完了後の自動起動なし） |
+| `globalVars.appArgs.launcher` | `--launcher` | `nvdaLauncher` が展開した一時コピー（セットアップ exe の主経路） |
+
+```python
+def _connectionBeepsEnabled():
+    return not (
+        globalVars.appArgs.install
+        or globalVars.appArgs.installSilent
+        or globalVars.appArgs.launcher
+    )
+```
+
+**抑制する音（3 ドライバ共通の接続試行まわり）**
+
+| 関数 | 音 | 対象モジュール |
+|------|-----|----------------|
+| `_fixConnection` | 待機ループ中の上昇ビープ（400Hz + 20×loop、20ms）、タイムアウト時の失敗音（200Hz、100ms） | `kgs`, `brailleMemo`, `kgsbn46` |
+| `waitAfterDisconnect` | 切断後スイープ（450Hz から逓減、10 回） | `kgs`（`brailleMemo` は同名関数を同条件で実装）、`kgsbn46` は `kgs.waitAfterDisconnect` を import |
+
+**抑制しない音**
+
+| 箇所 | 音 | 理由 |
+|------|-----|------|
+| `nvdaKgsStatusChangedProc` 等のステータスコールバック | 接続成功 1000Hz 30ms、切断 1000Hz 300ms | #470 の対象は長時間のプローブ列；接続確定／切断の短いフィードバックは従来どおり |
+
+**通常起動**
+
+- 上記 3 フラグがすべて偽（インストール済み NVDA の通常起動）では **従来どおりプローブ音が鳴る**。
+
+**コード配置**
+
+- 判定の正: `source/brailleDisplayDrivers/kgs.py` の `_connectionBeepsEnabled`
+- `brailleMemo.py`: `from .kgs import _connectionBeepsEnabled`
+- `kgsbn46.py`: 同上 + 独自 `_fixConnection` に適用
+
+**検証の目安**
+
+1. KGS USB ドライバーあり・端末未接続でランチャーまたは `--install` 起動 → インストール関連の読み上げ中に **プローブ音が連続しない**こと。
+2. 通常起動で点字「自動」・KGS 対象 COM あり → **プローブ音は従来どおり**（接続試行のフィードバックが残ること）。
+3. 実機接続時 → 接続／切断の短いステータスビープは **変わらない**こと（任意）。
+
+**今後の拡張**
+
+- ユーザー設定で常時 on/off する案（`BooleanDriverSetting`）は §2.4・§5.3 の「接続音 on/off」と同系。現状は **インストール系プロセスのみ**コードで抑制。
+
 ---
 
 ## 3. コード品質・保守上の論点（現状評価）
@@ -140,7 +199,7 @@ KGS 系は **2011 年頃から**（著作権表記: Shinke / Misono / Nishimoto�
 - `kgs.py` の **豊富な `gestureMap`**（キーボードエミュレーション）
 - `brailleMemo.py` の **8 点コンピュータ点字**（`BrailleInputGesture`）
 - `kgsbn46.py` の **46 系専用キー・KBDC 名・自動ポートスキャン**
-- 接続・切断時の **トーン + `processEvents()`** による利用者向けフィードバック
+- 接続・切断時の **トーン + `processEvents()`** による利用者向けフィードバック（インストール／ランチャー時はプローブ音のみ抑制、§2.6）
 
 ### 3.2 技術的負債（把握のみ／即修正不要）
 
@@ -207,6 +266,7 @@ KGS 系は **2011 年頃から**（著作権表記: Shinke / Misono / Nishimoto�
 | 項目 | 内容 |
 |------|------|
 | 既知事象の文書化 | 自動検出の繰り返し（readmejp 記載）を本 doc にリンク |
+| #470 対応 | インストール／ランチャー時の接続プローブ音抑制（§2.6、PR #659） |
 | 静的整理 | `kgsbn46` の Py2 残骸削除、例外処理の明確化（挙動不変） |
 | 調査 | `kgsbn46` ルーティングキー decode の実機確認（バグなら最小修正） |
 
@@ -239,6 +299,9 @@ KGS 系は **2011 年頃から**（著作権表記: Shinke / Misono / Nishimoto�
 | 参考実装 | `source/brailleDisplayDrivers/brailleNote.py`, `hims.py`, `dotPad/driver.py` |
 | アドオン生成 | `jptools/pack_kgs_addon.py`, `pack_kgs_addon.cmd`, `kgs_manifest.py` |
 | bdDetect 検証 | `jptools/kgs_bdDetect_probe.py` |
+| 起動引数 | `source/argsParsing.py`, `source/globalVars.py`（`appArgs.install` / `installSilent` / `launcher`） |
+| ランチャー | `launcher/nvdaLauncher.nsi`（`--launcher` 付与） |
+| Issue / PR | [#470](https://github.com/nvdajp/nvdajp/issues/470), [#659](https://github.com/nvdajp/nvdajp/pull/659) |
 | ユーザ doc | `user_docs/en/readmejp.md` |
 | 変更履歴 | `projectDocs/jp/changes-nvdajp.md` |
 
@@ -251,6 +314,7 @@ KGS 系は **2011 年頃から**（著作権表記: Shinke / Misono / Nishimoto�
 | 2026-05-18 | 初版（現状・NVDA 仕様差分・方針案） |
 | 2026-05-18 | アドオン `lastTestedNVDAVersion` を 2026.1.1 に更新 |
 | 2026-05-18 | Next Touch 40 向け `VID_10C4&PID_EA60` の bdDetect 登録、`kgs_bdDetect_probe.py` 追加 |
+| 2026-05-25 | §2.6: インストール／ランチャー時の接続プローブ音抑制（#470 / PR #659） |
 
 ---
 

--- a/source/brailleDisplayDrivers/brailleMemo.py
+++ b/source/brailleDisplayDrivers/brailleMemo.py
@@ -7,6 +7,8 @@
 # Copyright (C) 2013 Masamitsu Misono
 # Copyright (C) 2011-2022 Takuya Nishimoto
 
+from .kgs import _connectionBeepsEnabled
+
 import braille
 import brailleInput
 import inputCore
@@ -314,10 +316,12 @@ def _fixConnection(hBrl, devName, port, keyCallbackInst, statusCallbackInst):
 				log.debug("isUnknownEquipment")
 				break
 			time.sleep(0.5)
-			tones.beep(400 + (loop * 20), 20)
+			if _connectionBeepsEnabled():
+				tones.beep(400 + (loop * 20), 20)
 			processEvents()
 		else:
-			tones.beep(200, 100)
+			if _connectionBeepsEnabled():
+				tones.beep(200, 100)
 	if not fConnection:
 		bmDisConnect(hBrl, _port)
 		port = None
@@ -340,10 +344,11 @@ def processEvents():
 def waitAfterDisconnect():
 	for loop in range(10):
 		time.sleep(0.5)
-		try:
-			tones.beep(450 - (loop * 20), 20)
-		except:  # noqa: E722
-			pass
+		if _connectionBeepsEnabled():
+			try:
+				tones.beep(450 - (loop * 20), 20)
+			except:  # noqa: E722
+				pass
 		processEvents()
 
 

--- a/source/brailleDisplayDrivers/kgs.py
+++ b/source/brailleDisplayDrivers/kgs.py
@@ -12,6 +12,7 @@ import braille
 import inputCore
 import hwPortUtils
 import time
+import globalVars
 import tones
 import os
 from collections import OrderedDict
@@ -38,6 +39,15 @@ numCells = 0
 isUnknownEquipment = False
 
 locked = False
+
+
+def _connectionBeepsEnabled():
+	"""Return False during install or launcher so connection tones do not mask speech."""
+	return not (
+		globalVars.appArgs.install
+		or globalVars.appArgs.installSilent
+		or globalVars.appArgs.launcher
+	)
 
 
 def lock():
@@ -371,10 +381,12 @@ def _fixConnection(hBrl, devName, port, keyCallbackInst, statusCallbackInst):
 				log.debug("isUnknownEquipment")
 				break
 			time.sleep(0.5)
-			tones.beep(400 + (loop * 20), 20)
+			if _connectionBeepsEnabled():
+				tones.beep(400 + (loop * 20), 20)
 			processEvents()
 		else:
-			tones.beep(200, 100)
+			if _connectionBeepsEnabled():
+				tones.beep(200, 100)
 	if not fConnection:
 		bmDisConnect(hBrl, _port)
 		port = None
@@ -397,10 +409,11 @@ def processEvents():
 def waitAfterDisconnect():
 	for loop in range(10):
 		time.sleep(0.5)
-		try:
-			tones.beep(450 - (loop * 20), 20)
-		except:  # noqa: E722
-			pass
+		if _connectionBeepsEnabled():
+			try:
+				tones.beep(450 - (loop * 20), 20)
+			except:  # noqa: E722
+				pass
 		processEvents()
 
 

--- a/source/brailleDisplayDrivers/kgsbn46.py
+++ b/source/brailleDisplayDrivers/kgsbn46.py
@@ -25,6 +25,7 @@ else:
 	byte = chr
 
 from .kgs import (
+	_connectionBeepsEnabled,
 	kgsListComPorts,
 	waitAfterDisconnect,
 	kgs_dir,
@@ -151,12 +152,14 @@ def _fixConnection(hBrl, devName, port, keyCallbackInst, statusCallbackInst):
 				log.info("isUnknownEquipment")
 				break
 			time.sleep(0.5)
-			tones.beep(400 + (loop * 20), 20)
+			if _connectionBeepsEnabled():
+				tones.beep(400 + (loop * 20), 20)
 			processEvents()
 	if not fConnection:
 		bmDisConnect(hBrl, _port)
 		port = None
-		tones.beep(200, 100)
+		if _connectionBeepsEnabled():
+			tones.beep(200, 100)
 	log.info("connection:%d port:%d" % (fConnection, _port))
 	return fConnection, port
 


### PR DESCRIPTION
## Summary
- Add `_connectionBeepsEnabled()` in `kgs.py`; return false when `--install`, `--install-silent`, or `--launcher` is active.
- Gate connection-probe tones in `_fixConnection` and `waitAfterDisconnect` for `kgs`, `brailleMemo`, and `kgsbn46`.
- Fixes [nvdajp/nvdajp#470](https://github.com/nvdajp/nvdajp/issues/470): install speech is no longer masked by KGS auto-detection beeps when the USB driver is present but the display is not connected.

## Test plan
- [ ] KGS USB driver installed, display unplugged: run NVDA launcher install; confirm install messages are readable without connection beeps.
- [ ] Normal NVDA start (not install/launcher): connection beeps still play when probing COM ports.
- [ ] Smoke test with BMS40/BM46 if available: auto connect still works and connect/disconnect status beeps unchanged.