### PR TITLE
Fix -j2 cert build implicit dist exe deps

### DIFF
--- a/jptools/scons_jp.py
+++ b/jptools/scons_jp.py
@@ -1158,6 +1158,20 @@ def register_jp_builders(env: Any, dist_target: Any | None = None, source_dir: A
 				candidates.append(dll_path)
 			else:
 				missing_required.append(dll_path)
+
+		# Sign critical EXEs in dist/ (certificate store builds).
+		# These were previously signed as part of NVDADistGenerator, but that introduces implicit
+		# dependencies on dist/*.exe which are side effects, not SCons targets, and can fail under -j2.
+		for exe_name in [
+			"nvda_noUIAccess.exe",
+			"nvda_uiAccess.exe",
+			"nvda_slave.exe",
+			"l10nUtil.exe",
+			"uninstall.exe",
+		]:
+			exe_path = dist_dir / exe_name
+			if exe_path.exists():
+				candidates.append(exe_path)
 		# Sign files in dist/lib/<version>/ (nvdaHelper*.dll, etc.)
 		# These files are copied from source/ to dist/ during dist build, but may lose signatures
 		# during the copy process. We sign them here to ensure they are signed before launcher build.

--- a/sconstruct
+++ b/sconstruct
@@ -463,18 +463,9 @@ def NVDADistGenerator(target, source, env, for_signature):
 
 	# BEGIN JP PATCH (certificate store signing support)
 	if certFile or apiSigningToken or useCertStore:
-		# nvda_synthDriverHost.exe: JP signs it via buildSynthDriverHost32.ps1 before scons; upstream
-		# added it here with "if not os.path.isfile(...): continue" but that broke the 4 exes (at
-		# generator time dist does not exist yet). JP keeps the 4 exes only.
-		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe":
-			# Avoid late-binding issues in lambdas: bind `path` and `node` by value.  # nvdajp
-			path = os.path.join(target[0].path, prog)  # nvdajp
-			node = File(path)  # nvdajp
-			action.append(
-				lambda target, source, env, pathByVal=path, nodeByVal=node: (
-					env["signExec"]([nodeByVal], source, env) if os.path.isfile(pathByVal) else None
-				),
-			)
+		# JP signs dist/*.exe via jpCertExtras after dist is built.  # nvdajp
+		# Signing these here (as part of NVDADistGenerator) introduces implicit dependencies on
+		# dist/l10nUtil.exe etc. which are not SCons targets, and can fail under -j2.  # nvdajp
 	# END JP PATCH (certificate store signing support)
 
 	action.extend((Delete(buildVersionFn), Delete(importlib.util.cache_from_source(buildVersionFn))))

--- a/sconstruct
+++ b/sconstruct
@@ -466,6 +466,7 @@ def NVDADistGenerator(target, source, env, for_signature):
 		# JP signs dist/*.exe via jpCertExtras after dist is built.  # nvdajp
 		# Signing these here (as part of NVDADistGenerator) introduces implicit dependencies on
 		# dist/l10nUtil.exe etc. which are not SCons targets, and can fail under -j2.  # nvdajp
+		pass  # nvdajp
 	# END JP PATCH (certificate store signing support)
 
 	action.extend((Delete(buildVersionFn), Delete(importlib.util.cache_from_source(buildVersionFn))))


### PR DESCRIPTION
## Summary
- Stop signing dist/*.exe inside NVDADistGenerator (this created implicit dependencies like dist/l10nUtil.exe which are side effects and can fail under -j2).
- Sign critical dist EXEs in jpCertExtras after dist is built.

## Test plan
- [ ] Re-run local signed build with -j2 (alphajp daily)
- [ ] CI testAndPublish.yml on this PR