### PR TITLE
Support VS 2026 18.7+ LLVM directory layout in liblouis build

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -49,12 +49,22 @@ def getLouisVersion():
 
 
 # Liblouis is build with Clang, as Microsoft Visual C++ is unable to build C99 code.
-clangDirs = glob.glob(os.path.join(find_vc_pdir(env.get("MSVC_VERSION"), env), r"Tools\Llvm\bin"))
+# BEGIN JP PATCH (support VS 2026 18.7+ LLVM directory layout)
+# Visual Studio 2026 (18.7+) no longer ships the x86-hosted Tools\Llvm\bin
+# directory; Clang lives only in host-arch specific directories such as
+# Tools\Llvm\x64\bin. Accept either layout and put the found directory on the
+# build PATH so clang-cl resolves regardless of what vcvars added.
+_vcDir = find_vc_pdir(env.get("MSVC_VERSION"), env)
+clangDirs = glob.glob(os.path.join(_vcDir, r"Tools\Llvm\bin")) or glob.glob(
+	os.path.join(_vcDir, r"Tools\Llvm\x64\bin"),
+)
 if len(clangDirs) == 0:
 	raise RuntimeError(
 		"Could not find the Clang compiler. "
 		"Perhaps the C++ Clang tools for Windows component in visual Studio is not installed",
 	)
+env.PrependENVPath("PATH", clangDirs[0])
+# END JP PATCH (support VS 2026 18.7+ LLVM directory layout)
 env["CC"] = "clang-cl"
 env["M4"] = f'"{env.File("#miscdeps/tools/m4.exe")}"'
 # Liblouis disables GNU extensions for m4


### PR DESCRIPTION
## Summary

Visual Studio 2026 **18.7** no longer ships the x86-hosted `VC\Tools\Llvm\bin` directory — Clang lives only in host-arch specific directories such as `VC\Tools\Llvm\x64\bin`. The liblouis sconscript hard-coded the old path in its Clang existence check, so **SConstruct parsing fails** with:

```
RuntimeError: Could not find the Clang compiler. Perhaps the C++ Clang tools for Windows component in visual Studio is not installed
```

This breaks *every* scons invocation (including `scons jtalkSync`) on a machine with VS 2026 18.7, because the check runs at sconscript load time. The current CI image (vs2026 = 18.6.x) still has the old layout, so CI is green today — **but it will hit this as soon as the runner image updates to 18.7+**.

## Changes

- Accept either LLVM layout: `Tools\Llvm\bin` (≤18.6 / VS2022) or `Tools\Llvm\x64\bin` (18.7+).
- Prepend the found directory to the build `PATH` so `clang-cl` resolves regardless of what the MSVC tool setup added (previously the detected path was checked but never used).

## Verification

- Local machine with VS 2026 Community **18.7.0** (plus VS 2022): previously failed as above; with this patch `scons jtalkSync` succeeds and the full JP smoke test suite passes via `jptools/runJpSmokeTests.ps1` (translator2 all passed, translator_louis 6/6, JtalkTests OK).
- On the current CI image (18.6) the first glob matches as before, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)