### PR TITLE
Remove JTalk dict workarounds after deterministic rebuild fix

### DIFF
--- a/jptools/verifyJtalkDictionary.ps1
+++ b/jptools/verifyJtalkDictionary.ps1
@@ -7,11 +7,8 @@
     custom-dictionary entries. Use after jtalkSync to catch cache pollution
     or incorrect dictionary builds before running full smoke tests.
 
-    - CI (GITHUB_ACTIONS): the workflow passes -Strict, because the dictionary
-      build is not reproducible and basic cases pass even against a broken
-      sys.dic (entries present but unreachable via the index). Without -Strict
-      the GHA default is basic.
-    - Local / certBuild: strict cases by default (二百十日, ごめんください, etc.).
+    - Default: strict verification (basic + extended custom-dic cases).
+    - CI workflow passes -Strict explicitly; verify_dic.py also defaults to strict.
 
 .PARAMETER Strict
     Force strict verification (basic + extended custom-dic cases).
@@ -77,7 +74,7 @@ if (-not (Test-Path $verifyScript)) {
     exit 1
 }
 
-$modeHint = if ($env:JP_VERIFY_DIC_MODE) { $env:JP_VERIFY_DIC_MODE } elseif ($isCI) { "basic (CI default)" } else { "strict (local default)" }
+$modeHint = if ($env:JP_VERIFY_DIC_MODE) { $env:JP_VERIFY_DIC_MODE } else { "strict (default)" }
 Write-Host "Verifying JTalk dictionary (mode: $modeHint)..."
 & $pythonExe $verifyScript
 exit $LASTEXITCODE

--- a/miscDepsJp/jptools/verify_dic.py
+++ b/miscDepsJp/jptools/verify_dic.py
@@ -20,10 +20,7 @@ dic_dir = jtalk_dir / "dic"
 sys.path.insert(0, str(jtalk_dir))
 
 # Verification cases: (input_text, expected_output)
-# CI passes JP_VERIFY_DIC_MODE=strict (via verifyJtalkDictionary.ps1 -Strict):
-# a non-reproducible dictionary build can produce a sys.dic that passes every
-# basic case while strict-case entries are unreachable via the index.
-# Local/certBuild: strict custom-dictionary coverage before release smoke tests.
+# Default is strict (basic + extended). Pass JP_VERIFY_DIC_MODE=basic to limit cases.
 CASES_BASIC = [
 	("一人", "ヒトリ"),
 	("二人", "フタリ"),
@@ -40,12 +37,6 @@ CASES_STRICT = [
 def _cases_for_run() -> list[tuple[str, str]]:
 	mode = os.environ.get("JP_VERIFY_DIC_MODE", "").strip().lower()
 	if mode == "basic":
-		return list(CASES_BASIC)
-	if mode == "strict":
-		return CASES_BASIC + CASES_STRICT
-	# Default when JP_VERIFY_DIC_MODE is unset: basic on GHA (the CI workflow
-	# passes strict explicitly); strict locally.
-	if os.environ.get("GITHUB_ACTIONS") == "true":
 		return list(CASES_BASIC)
 	return CASES_BASIC + CASES_STRICT
 

--- a/projectDocs/jp/roadmap.md
+++ b/projectDocs/jp/roadmap.md
@@ -41,8 +41,9 @@
   - 根本原因（mecab-dict-index の config-charset 誤設定 → ContextID 解決失敗 →
     未定義動作でゴミ文脈 ID）を 2026-06-12 に特定・修正済み。
     `make_jdic.py` 2 回連続実行で sys.dic がバイト一致することを確認。
-  - 残り: translator2.py の出力補正と verify_dic.py の GHA basic 縮退の撤去、
-    カスタムエントリへの品詞別文脈 ID 付与（コスト再調整を伴う将来課題）。
+  - translator2.py の出力補正（一人/二人/おはようございます）と
+    verify_dic.py の GHA basic 縮退の撤去は 2026-06-12 に実施済み。
+  - 将来課題: カスタムエントリへの品詞別文脈 ID 付与（コスト再調整を伴う）。
   - 参照: `projectDocs/jp/tab-character-analysis.md`
     「非決定性の根本原因の特定と修正 (2026-06-12)」
 - **タスク 2.6 CI基盤の最小限更新**

--- a/projectDocs/jp/tab-character-analysis.md
+++ b/projectDocs/jp/tab-character-analysis.md
@@ -976,6 +976,7 @@ run 27351400056（rerun、image 20260525.121.1、translator2 成功）の artifa
   検証済み辞書を成果物として固定し辞書ソース変更時のみ再ビルドする方式の検討。
   非決定性が同一環境でも発生する以上、ランナー固定方向の対策は効果が見込めない
 * 根本対応後、translator2.py の出力補正（おはようございます等）と verify_dic.py の GHA basic 縮退を撤去する
+  （**2026-06-12 実施済み**: `betajp-jtalk-dic-followup`）
 
 ## 非決定性の根本原因の特定と修正 (2026-06-12)
 
@@ -1070,3 +1071,21 @@ naist データで常に fail する。posid は nvdajp ランタイム（jtalk 
 * 成功ラン（betajp）: <https://github.com/nvdajp/nvdajp/actions/runs/27309955248>
 * 検証ケース定義: `miscDepsJp/jptools/verify_dic.py`（CASES_BASIC / CASES_STRICT）
 * 点訳エントリの生成: `miscDepsJp/jptools/jtalk/filter_jdic.py`（例: 寄付行為 → キフ コーイ）
+
+## 後続: 出力補正と verify_dic 縮退の撤去 (2026-06-12)
+
+辞書ビルドの決定性が確認できたため、2026-03-30 に入れた暫定対策を撤去した。
+
+### 変更内容
+
+* `source/synthDrivers/jtalk/translator2.py`:
+  一人/二人の分割マージ（`一`+`人` → `ヒトリ`）と
+  おはようございますの読み補正（`オハヨーゴザイマス` → `オハヨー ゴザイマス`）を削除。
+  カスタム辞書の点訳専用フィールド（16 番目）が正しく適用される前提に戻した
+* `miscDepsJp/jptools/verify_dic.py`:
+  `GITHUB_ACTIONS=true` 時の CASES_BASIC のみ実行を廃止。未指定時は常に strict
+* `jptools/verifyJtalkDictionary.ps1`: 上記に合わせて説明と mode 表示を更新
+
+### 検証
+
+* `verifyJtalkDictionary.ps1`（strict 6 件）と `JpBrailleTests.test_translator2` で回帰確認

--- a/source/synthDrivers/jtalk/translator2.py
+++ b/source/synthDrivers/jtalk/translator2.py
@@ -1447,35 +1447,6 @@ def japanese_braille_separate(inbuf, logwrite, nabcc=False, use_foreign_quotes=F
 
 	li = [mo for mo in li if mo.hyouki]
 
-	# nvdajp: stabilize a few high-impact compounds against CI-dependent segmentation.
-	# If MeCab splits "一人"/"二人" as "一"+"人"/"二"+"人", rewrite_number() later turns "一"/"二" into digits,
-	# producing "1ニン"/"2ニン". Merge here so downstream processing is stable.
-	_new_li = []
-	i = 0
-	while i < len(li):
-		mo = li[i]
-		mo2 = li[i + 1] if i + 1 < len(li) else None
-		if mo2 and mo.hyouki in ("一", "二") and mo2.hyouki == "人" and mo.hinshi2 == "数":
-			m = copy.deepcopy(mo)
-			m.hyouki = m.nhyouki = ("一人" if mo.hyouki == "一" else "二人")
-			m.hinshi1 = "名詞"
-			m.hinshi2 = "一般"
-			m.kihon = m.hyouki
-			m.kana = m.yomi = ("ヒトリ" if mo.hyouki == "一" else "フタリ")
-			m.output = m.yomi
-			m.accent = "2/3" if mo.hyouki == "一" else "0/3"
-			m.sepflag = False
-			_new_li.append(m)
-			i += 2
-			continue
-		_new_li.append(mo)
-		i += 1
-	li = _new_li
-
-	# nvdajp: normalize a common greeting reading to include a word boundary.
-	for mo in li:
-		if mo.hyouki == "おはようございます" and mo.output == "オハヨーゴザイマス":
-			mo.output = "オハヨー ゴザイマス"
 	for mo in li:
 		if TAB_CODE in mo.nhyouki:
 			mo.hinshi1 = "記号"
@@ -1801,18 +1772,6 @@ def japanese_braille_separate(inbuf, logwrite, nabcc=False, use_foreign_quotes=F
 		outbuf = outbuf.replace(TAB_CODE, "⡀")
 	else:
 		outbuf = outbuf.replace(TAB_CODE, " ")
-
-	# nvdajp: CI stability for a legacy greeting.
-	# Some environments end up with "オハヨーゴザイマス" (no word boundary).
-	# Normalize only for the exact input/reading pair to avoid unexpected changes elsewhere.
-	if inbuf == "おはようございます" and outbuf == "オハヨーゴザイマス":
-		outbuf = "オハヨー ゴザイマス"
-		# Insert mapping for the added space: point to the preceding character.
-		# This keeps inpos2 length consistent with outbuf without affecting callers that ignore positions.
-		space_pos = len("オハヨー")
-		if isinstance(inpos2, list) and len(inpos2) == len("オハヨーゴザイマス"):
-			insert_map = inpos2[space_pos - 1] if space_pos - 1 < len(inpos2) else 0
-			inpos2.insert(space_pos, insert_map)
 
 	return (outbuf, inpos2)
 


### PR DESCRIPTION
## Summary

- Remove temporary 	ranslator2.py output patches for 一人/二人/おはようございます now that custom-dictionary braille fields apply reliably after the mecab-dict-index determinism fix (roadmap task 2.7 follow-up).
- Make erify_dic.py default to strict everywhere; drop the GHA CASES_BASIC-only fallback that masked broken sys.dic builds.
- Update JP docs (oadmap.md, 	ab-character-analysis.md) to record completion of this follow-up.

## Test plan

- [x] Local: erifyJtalkDictionary.ps1 strict (6 cases) — all OK
- [x] Local: GITHUB_ACTIONS=true without JP_VERIFY_DIC_MODE — strict 6 cases OK
- [x] Local: JpBrailleTests.test_translator2 — OK
- [ ] CI: 	estAndPublish.yml (Verify JTalk dictionary + jpSmokeTests)