### PR TITLE
Fix JTalk compound number reading regression guard

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -46,9 +46,11 @@ env:
   # Bumped to v4: mecab-dict-index sources patched (config-charset UTF-8, ContextID
   # hardening) and dic makers now emit explicit context ids; cached .obj files
   # from the old sources must not be linked into the new tool.
+  # Bumped to v5: force libopenjtalk rebuild so njd_set_digit stays SHIFT_JIS
+  # (UTF-8 njd_set_digit + Mecab_utf8_to_cp932 breaks compound number readings).
   # Do not bump on every CI failure; investigate logs first.
   # See projectDocs/jp/tab-character-analysis.md "キャッシュキーで無効化".
-  SCONS_CACHE_SUFFIX: "-jp-v4"
+  SCONS_CACHE_SUFFIX: "-jp-v5"
 
 jobs:
   matrix:

--- a/miscDepsJp/include/libopenjtalk/njd_set_digit/Makefile.mak
+++ b/miscDepsJp/include/libopenjtalk/njd_set_digit/Makefile.mak
@@ -1,6 +1,7 @@
 
 CC = cl
 
+# Keep SHIFT_JIS while jtalkDriver calls Mecab_utf8_to_cp932 before libjt_synthesis.
 CFLAGS = /O2 /Ob2 /Oi /Ot /Oy /GT /GL /TC /I ../njd /D CHARSET_SHIFT_JIS /source-charset:shift_jis /execution-charset:shift_jis
 LFLAGS = /LTCG
 

--- a/miscDepsJp/jptools/jtalk_pipeline_probe.py
+++ b/miscDepsJp/jptools/jtalk_pipeline_probe.py
@@ -32,6 +32,7 @@ if str(JTALK_DIR) in sys.path:
 sys.path.insert(0, str(JTALK_DIR))
 
 import jtalkPrepare  # type: ignore
+import jtalkCore  # type: ignore
 from jtalkCore import (  # type: ignore
 	libjt_initialize,
 	libjt_load,
@@ -121,6 +122,54 @@ def initialize() -> None:
 def probe_text(text: str, feature_limit: int = 8) -> dict:
 	initialize()
 	return _probe_one(text, feature_limit=feature_limit)
+
+
+def probe_digit_compound(text: str = "12") -> dict:
+	"""Check njd_set_digit merges ASCII digits into compound readings.
+
+	While Mecab_utf8_to_cp932 runs before libjt_synthesis, njd_set_digit must stay
+	compiled as CHARSET_SHIFT_JIS. UTF-8 rule tables against CP932 node strings
+	fail strcmp and leave digit-by-digit readings (イチ+ニ instead of ジュウニ).
+	"""
+	from ctypes import string_at
+
+	initialize()
+	assert jtalkCore.libjt is not None
+	prepared = jtalkPrepare.convert(text)
+	src = text2mecab(prepared)
+	mf = MecabFeatures()
+	Mecab_analysis(src, mf)
+	Mecab_correctFeatures(mf)
+	mecab_token_count = mf.size
+	Mecab_utf8_to_cp932(mf)
+	libjt = jtalkCore.libjt
+	njd = jtalkCore.njd
+	jpcommon = jtalkCore.jpcommon
+	libjt.mecab2njd(njd, mf.feature, mf.size)
+	libjt.njd_set_pronunciation(njd)
+	libjt.njd_set_digit(njd)
+	libjt.njd2jpcommon(jpcommon, njd)
+	libjt.JPCommon_make_label(jpcommon)
+	label_count = libjt.JPCommon_get_label_size(jpcommon)
+	label_feature = libjt.JPCommon_get_label_feature(jpcommon)
+	labels = "".join(
+		string_at(label_feature[i]).decode("ascii", errors="replace")
+		for i in range(label_count)
+	)
+	libjt_refresh()
+	labels_lower = labels.lower()
+	# Merged twelve: ju-mora path. Digit-by-digit: i+ch (イチ) mora path.
+	digit_merged = ("j+u" in labels_lower or "j-u" in labels_lower) and (
+		"i+ch" not in labels_lower and "i-ch" not in labels_lower
+	)
+	return {
+		"text": text,
+		"mecabTokenCount": mecab_token_count,
+		"labelCount": label_count,
+		"hasWave": label_count > 2,
+		"digitMerged": digit_merged,
+		"labelsSnippet": labels[:400],
+	}
 
 
 def main() -> int:

--- a/miscDepsJp/jptools/test.py
+++ b/miscDepsJp/jptools/test.py
@@ -89,6 +89,16 @@ class JtalkTests(unittest.TestCase):
 		self.assertGreater(result["tokenCount"], 20)
 		self.assertIn("nvda", result["prepared"].lower())
 
+	def test_jtalk_digit_compound_twelve(self):
+		"""12 must be synthesized as juu-ni, not digit-by-digit ichi-ni."""
+		result = jtalk_pipeline_probe.probe_digit_compound("12")
+		self.assertTrue(result["hasWave"])
+		self.assertEqual(result["mecabTokenCount"], 2)
+		self.assertTrue(
+			result["digitMerged"],
+			"njd_set_digit failed to merge 12; labels=%r" % result["labelsSnippet"],
+		)
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/projectDocs/jp/tab-character-analysis.md
+++ b/projectDocs/jp/tab-character-analysis.md
@@ -1089,3 +1089,32 @@ naist データで常に fail する。posid は nvdajp ランタイム（jtalk 
 ### 検証
 
 * `verifyJtalkDictionary.ps1`（strict 6 件）と `JpBrailleTests.test_translator2` で回帰確認
+
+## JTalk 複合数読み回帰（2026-06-12, alphajp 調査 → betajp 修正）
+
+### 症状
+
+alphajp ビルド（betajp 取り込み直後）で、メニュー位置「6の12」等が
+「ロクノイチニ」と桁読みになる。期待は「ロクノジュウニ」。
+
+### 原因
+
+`jtalkDriver._jtalk_speak` は合成前に `Mecab_utf8_to_cp932` で feature を
+CP932 化する一方、`njd_set_digit` を `CHARSET_UTF_8` でコンパイルすると
+規則テーブルとの `strcmp` が失敗し、MeCab が分割した `１`+`２` を結合できない。
+
+`jpcommon` / `njd2jpcommon` が Shift_JIS のままである限り、CP932 変換は必要で、
+**`njd_set_digit` は Shift_JIS を維持**する必要がある。
+
+betajp 本体の Makefile は Shift_JIS のまま。alphajp 側で UTF-8 化された
+コミットがマージ経路に入ると再発する。
+
+### 対応（betajp-jtalk-follow-up）
+
+* `miscDepsJp/include/libopenjtalk/njd_set_digit/Makefile.mak`:
+  Shift_JIS 維持をコメントで明示
+* `miscDepsJp/jptools/jtalk_pipeline_probe.py`:
+  `probe_digit_compound("12")` で HTS ラベルから桁結合を検証
+* `miscDepsJp/jptools/test.py`:
+  `JtalkTests.test_jtalk_digit_compound_twelve` を追加
+* `SCONS_CACHE_SUFFIX` を `-jp-v5` に bump（stale `njd_set_digit.obj` 回避）


### PR DESCRIPTION
## Summary
- alphajp で再現した「12」→イチニ桁読みの原因は、UTF-8 化した `njd_set_digit` と合成前 `Mecab_utf8_to_cp932` の不整合であることを文書化
- `njd_set_digit` を Shift_JIS 維持と明記し、`probe_digit_compound("12")` と `JtalkTests.test_jtalk_digit_compound_twelve` で桁結合を自動検証
- stale `njd_set_digit.obj` 回避のため `SCONS_CACHE_SUFFIX` を `-jp-v5` に bump

## Test plan
- [x] `jptools/runJpSmokeTests.ps1 -SkipInstall -TestFilter JtalkTests.test_jtalk_digit_compound_twelve`
- [ ] CI `allTestsPass`