### PR TITLE
fix(IME): speak Clear when composition is fully deleted (#656)

### DIFF
--- a/source/NVDAHelper/__init__.py
+++ b/source/NVDAHelper/__init__.py
@@ -471,7 +471,7 @@ def _handleCompAttrCompositionEnd(lastString: str) -> None:
 	global lastCompositionEndTime
 	from NVDAObjects import inputComposition as ic
 
-	if ic.compositionCommitFromEnter:
+	if ic.isCompositionCommitFromEnter():
 		lastCompositionEndTime = time.time()
 		resetInputCompositionVariables()
 		handleInputCompositionEnd("", cancelled=False)
@@ -583,6 +583,9 @@ def handleInputCompositionStart(compositionString, selectionStart, selectionEnd,
 		if parent == focus:
 			parent = focus
 		curInputComposition = InputComposition(parent=parent)
+		from NVDAObjects import inputComposition as ic
+
+		ic.beginCompositionSessionIfNeeded()
 		oldSpeechMode = speech.getState().speechMode
 		speech.setSpeechMode(speech.SpeechMode.off)
 		eventHandler.executeEvent("gainFocus", curInputComposition)
@@ -619,6 +622,10 @@ def nvdaControllerInternal_inputCompositionUpdate(compositionString, selectionSt
 			)
 			return 0
 		log.debug(f"({lastCompString=}) ({compositionString=})")
+		if compositionString and not lastCompString:
+			from NVDAObjects import inputComposition as ic
+
+			ic.beginCompositionSessionIfNeeded()
 		deletedString = ""
 		if (
 			lastCompString

--- a/source/NVDAHelper/__init__.py
+++ b/source/NVDAHelper/__init__.py
@@ -466,6 +466,20 @@ def nvdaControllerInternal_logMessage(level, pid, message):
 	return 0
 
 
+def _handleCompAttrCompositionEnd(lastString: str) -> None:
+	"""Resolve compAttr IME (empty, -1, -1) after queued key events may have run."""
+	global lastCompositionEndTime
+	from NVDAObjects import inputComposition as ic
+
+	if ic.compositionCommitFromEnter:
+		lastCompositionEndTime = time.time()
+		resetInputCompositionVariables()
+		handleInputCompositionEnd("", cancelled=False)
+	else:
+		resetInputCompositionVariables()
+		handleInputCompositionEnd(lastString, cancelled=True)
+
+
 def handleInputCompositionEnd(result, cancelled=False):
 	import speech
 	import characterProcessing
@@ -660,20 +674,14 @@ def nvdaControllerInternal_inputCompositionUpdate(compositionString, selectionSt
 				queueHandler.queueFunction(queueHandler.eventQueue, handleInputCompositionEnd, lastCompString, True)
 				return 0
 			# compAttr IME: when key events are off, lastKeyGesture is not populated; treat as
-			# cancel so Esc/Back still get "Clear". When key events are on, only treat as cancel
-			# when we see Escape or Backspace (commit often arrives before key, so avoid Enter bug).
+			# cancel so Esc/Back still get "Clear". When key events are on, defer cancel vs commit
+			# so Enter can set compositionCommitFromEnter before we decide (Google IME). MS-IME /
+			# ATOK send non-empty results on Enter, so (empty, -1, -1) without Enter is cancel.
 			if not config.conf["keyboard"]["nvdajpEnableKeyEvents"]:
 				queueHandler.queueFunction(queueHandler.eventQueue, handleInputCompositionEnd, lastCompString, True)
 				return 0
-			from NVDAObjects import inputComposition as ic
-			gesture = ic.lastKeyGesture
-			if gesture and gesture.vkCode in (winUser.VK_ESCAPE, winUser.VK_BACK):
-				queueHandler.queueFunction(queueHandler.eventQueue, handleInputCompositionEnd, lastCompString, True)
-				return 0
-			# Commit (composition end): record time so editableText can suppress false new-line
-			# report; then reset. Only here, not for non-end no-compAttr updates.
-			lastCompositionEndTime = time.time()
-			resetInputCompositionVariables()
+			queueHandler.queueFunction(queueHandler.eventQueue, _handleCompAttrCompositionEnd, lastCompString)
+			return 0
 	# nvdajp end
 	# END JP PATCH
 	from NVDAObjects.IAccessible.mscandui import ModernCandidateUICandidateItem
@@ -1071,11 +1079,14 @@ class _RemoteLoader:
 # nvdajp: Japanese input composition variables reset function
 def resetInputCompositionVariables():
 	global lastCompAttr, lastCompString, lastSelectionStart, lastSelectionEnd, lastHadCompAttr
+	from NVDAObjects import inputComposition as ic
+
 	lastCompAttr = None
 	lastCompString = None
 	lastSelectionStart = None
 	lastSelectionEnd = None
 	lastHadCompAttr = False
+	ic.resetCompositionKeyState()
 
 
 def badCompositionUpdate(compositionString: str, compAttr: str) -> bool:

--- a/source/NVDAObjects/inputComposition.py
+++ b/source/NVDAObjects/inputComposition.py
@@ -63,6 +63,34 @@ class InputCompositionTextInfo(OffsetsTextInfo):
 # nvdajp begin
 # from keyboardHandler.internal_keyDownEvent
 lastKeyGesture = None
+# Set when Enter is pressed during an active composition (compAttr IMEs may send
+# (empty, -1, -1) on commit as well as on cancel).
+compositionCommitFromEnter = False
+
+
+def resetCompositionKeyState() -> None:
+	global compositionCommitFromEnter
+	compositionCommitFromEnter = False
+
+
+def isInInputComposition(focus=None) -> bool:
+	if focus is None:
+		import api
+
+		focus = api.getFocusObject()
+	if isinstance(focus, InputComposition):
+		return True
+	if isinstance(focus.parent, InputComposition):
+		return True
+	if isinstance(focus, CandidateItemBehavior):
+		return isinstance(focus.parent, InputComposition)
+	return False
+
+
+def noteCompositionKeyDown(vkCode: int) -> None:
+	global compositionCommitFromEnter
+	if vkCode == winUser.VK_RETURN:
+		compositionCommitFromEnter = True
 
 
 def reportKeyDownEvent(gesture):

--- a/source/NVDAObjects/inputComposition.py
+++ b/source/NVDAObjects/inputComposition.py
@@ -63,14 +63,58 @@ class InputCompositionTextInfo(OffsetsTextInfo):
 # nvdajp begin
 # from keyboardHandler.internal_keyDownEvent
 lastKeyGesture = None
-# Set when Enter is pressed during an active composition (compAttr IMEs may send
-# (empty, -1, -1) on commit as well as on cancel).
-compositionCommitFromEnter = False
+# Session id for compAttr IME Enter vs cancel detection. compAttr IMEs may send
+# (empty, -1, -1) on commit as well as on cancel.
+_compositionSessionId = 0
+_compositionCommitEnterSessionId: int | None = None
+_compositionSessionInProgress = False
+
+
+def beginCompositionSessionIfNeeded() -> None:
+	global _compositionSessionId, _compositionCommitEnterSessionId, _compositionSessionInProgress
+	if _compositionSessionInProgress:
+		return
+	_compositionSessionId += 1
+	_compositionCommitEnterSessionId = None
+	_compositionSessionInProgress = True
+
+
+def endCompositionSession() -> None:
+	global _compositionSessionId, _compositionCommitEnterSessionId, _compositionSessionInProgress
+	_compositionCommitEnterSessionId = None
+	_compositionSessionInProgress = False
+	_compositionSessionId += 1
 
 
 def resetCompositionKeyState() -> None:
-	global compositionCommitFromEnter
-	compositionCommitFromEnter = False
+	endCompositionSession()
+
+
+def isCompositionActive() -> bool:
+	from NVDAHelper import lastCompString
+
+	if lastCompString:
+		return True
+	if not isInInputComposition():
+		return False
+	import api
+
+	focus = api.getFocusObject()
+	if isinstance(focus, InputComposition):
+		comp = focus
+	elif isinstance(focus.parent, InputComposition):
+		comp = focus.parent
+	else:
+		return False
+	return bool(comp.compositionString or comp.readingString)
+
+
+def isCompositionCommitFromEnter() -> bool:
+	return (
+		_compositionCommitEnterSessionId is not None
+		and _compositionCommitEnterSessionId == _compositionSessionId
+		and _compositionSessionInProgress
+	)
 
 
 def isInInputComposition(focus=None) -> bool:
@@ -88,9 +132,9 @@ def isInInputComposition(focus=None) -> bool:
 
 
 def noteCompositionKeyDown(vkCode: int) -> None:
-	global compositionCommitFromEnter
-	if vkCode == winUser.VK_RETURN:
-		compositionCommitFromEnter = True
+	global _compositionCommitEnterSessionId
+	if vkCode == winUser.VK_RETURN and isCompositionActive():
+		_compositionCommitEnterSessionId = _compositionSessionId
 
 
 def reportKeyDownEvent(gesture):

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -257,6 +257,14 @@ def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 			stickyNVDAModifier = None
 			stickyNVDAModifierLocked = False
 		gesture = KeyboardInputGesture(currentModifiers, vkCode, scanCode, extended)
+		# nvdajp begin
+		if config.conf["keyboard"]["nvdajpEnableKeyEvents"]:
+			from NVDAObjects import inputComposition
+
+			focus = api.getFocusObject()
+			if inputComposition.isInInputComposition(focus):
+				inputComposition.noteCompositionKeyDown(vkCode)
+		# nvdajp end
 		if not (stickyKeysFlags & winUser.SKF_STICKYKEYSON) and (
 			bypassNVDAModifier
 			or (


### PR DESCRIPTION
## Summary
- Issue #656 の残課題: 未変換文字を Backspace ですべて削除したときに「クリア」が読まれない問題を修正
- compAttr IME（MS-IME / ATOK 等）で \(empty, -1, -1)\ 終了時の判定を、\lastKeyGesture\ の Backspace 依存から \compositionCommitFromEnter\ フラグ + イベントキュー遅延判定に変更
- Enter 確定時の誤「クリア」回避ロジック（Google IME 向け）は維持

## 背景
2026.1jp の Enter 誤「クリア」対策で compAttr IME は Back/Esc の \lastKeyGesture\ のみキャンセル扱いにしていたが、IME コールバックと keyDown のタイミング差で Backspace 全削除が確定扱いになり「クリア」が出なかった。MS-IME / ATOK は Enter 確定時に非空 result を送るため、\(empty, -1, -1)\ は基本的にキャンセルとみなせる。

## Test plan
- [ ] メモ帳 + MS-IME: 未変換入力 → Backspace で全削除 →「クリア」が読まれる
- [ ] メモ帳 + ATOK: 同上
- [ ] 未変換 Backspace →「ブランク」が出ない（#657 回帰なし）
- [ ] Enter で変換確定 → 確定文字列が読まれ、誤「クリア」が入らない
- [ ] Esc で未確定キャンセル →「クリア」が読まれる
- [ ] 設定「nvdajp IME サポート」有効であること

Fixes nvdajp/nvdajp#656