### PR TITLE
Add JIS locale gesture for magnifier zoom in

### DIFF
--- a/projectDocs/jp/README.md
+++ b/projectDocs/jp/README.md
@@ -108,6 +108,7 @@ MeCab 初期化の実行順依存（jpSmokeTests 内で process-global な tagge
 
 ### 日本語機能・点字
 
+* 日本語キーボード向け locale ジェスチャ: `projectDocs/jp/locale-gestures-japanese-keyboard.md`
 * 日本語入力メソッド実装: `projectDocs/jp/japanese-input-method-implementation.md`
 * 日本語点字出力テーブル: `projectDocs/jp/braille-ja-jp-comp6.md`
 * 点字関連分析: `projectDocs/jp/braille-routing-analysis.md`、`projectDocs/jp/braille-tables-relationship.md`

--- a/projectDocs/jp/locale-gestures-japanese-keyboard.md
+++ b/projectDocs/jp/locale-gestures-japanese-keyboard.md
@@ -1,0 +1,29 @@
+# 日本語キーボード向け locale ジェスチャ
+
+`source/locale/ja/gestures.ini` は UI 言語が日本語のとき読み込まれる（`source/inputCore.py` の `loadLocaleGestureMap()`）。
+
+## 拡大鏡 zoomIn
+
+デフォルトは `source/globalCommands.py` の `kb:NVDA+shift+=`（`NVDA+Shift+イコール`）。**これは無効化せず残す。**
+
+JIS 配列では US 配列と違い `=` が物理キーではない。
+`+` は **Shift + セミコロン**（`;` キー）で入力する。
+これを踏まえて `locale/ja/gestures.ini` では JIS 向けの **追加** 割り当てを書く。
+
+```ini
+[globalCommands.GlobalCommands]
+	zoomIn = kb:NVDA+shift+;
+```
+
+- セクション: `[globalCommands.GlobalCommands]`
+- キー名: スクリプト名（`script_` なし）
+- NVDA は **物理キー名** で識別する（`source/keyboardHandler.py`）。
+- 入力ヘルプ（`NVDA+1`）で実際のキー名を確認できる
+
+## 優先順位
+
+1. `%AppData%\Roaming\NVDA\gestures.ini`（ユーザー設定）
+2. `locale/ja/gestures.ini`
+3. `@script(gesture=...)` のデフォルト
+
+正本: `source/locale/ja/gestures.ini`

--- a/source/locale/ja/gestures.ini
+++ b/source/locale/ja/gestures.ini
@@ -1,0 +1,2 @@
+[globalCommands.GlobalCommands]
+	zoomIn = kb:NVDA+shift+;


### PR DESCRIPTION
## Summary
- Add \source/locale/ja/gestures.ini\ with an additional \zoomIn\ binding for JIS keyboards (\NVDA+Shift+semicolon\)
- Document the locale gesture customization in \projectDocs/jp/locale-gestures-japanese-keyboard.md\
- Link the new doc from \projectDocs/jp/README.md\

The default \NVDA+Shift+equals\ binding from \globalCommands.py\ is left unchanged.

## Test plan
- [ ] Set NVDA UI language to Japanese and restart
- [ ] Press \NVDA+Shift+semicolon\ and confirm magnifier zoom in works
- [ ] Confirm the default \NVDA+Shift+equals\ binding still works where applicable
- [ ] Check input help (\NVDA+1\) shows the expected command name for the JIS binding