### PR TITLE
Unskip braille routing tests by pinning the braille table

### DIFF
--- a/projectDocs/jp/archive/test-routing-failures.md
+++ b/projectDocs/jp/archive/test-routing-failures.md
@@ -1,5 +1,10 @@
 # Braille Routing Unit Test Failures
 
+> **解決済み (2026-07-03)**: 根本原因は routing 実装ではなく、nvdajp の既定点字テーブル
+> (`ja-jp-comp6.utb`) が日本語点訳エンジンを経由するため、テストが前提とする
+> 「1 セル = 1 文字」のマッピングが崩れていたこと。テスト側でテーブルを明示指定して
+> スキップを解除した。詳細は `projectDocs/jp/braille-routing-analysis.md` を参照。
+
 ## 概要
 
 `tests/unit/test_braille/test_routing.py` の `TestReviewRoutingMovesSystemCaretInNavigableText` クラスで4つのテストが失敗しています。これらはすべて `ReviewCursorManagerRegion` の実装に関連する問題です。

--- a/projectDocs/jp/braille-routing-analysis.md
+++ b/projectDocs/jp/braille-routing-analysis.md
@@ -1,5 +1,25 @@
 # Braille Routing 問題の分析
 
+## 解決済み (2026-07-03)
+
+**真の根本原因**: routing 実装のバグではなく、**点字テーブルの既定値の違い**でした。
+
+- nvdajp は `config` の既定点字テーブルを `en-ueb-g1.ctb` から `ja-jp-comp6.utb` に変更している（`source/config/configSpec.py`）
+- `ja-jp-comp6.utb` の場合、`louisHelper.translate()` は liblouis ではなく日本語点訳エンジン（`synthDrivers.jtalk.translator2`）を使う
+- 日本語点訳エンジンはラテン文字テキストに外字符などの追加セルを挿入するため、点字セル位置と文字位置が 1 対 1 に対応しなくなる
+- upstream のテストは「1 セル = 1 文字」のマッピングを前提としており（upstream の既定テーブル `en-ueb-g1.ctb` ではこれが成立）、既定テーブルのまま実行すると `routeTo(3)` が文字位置 2 に解決される等のズレが生じて失敗していた
+- `ReviewCursorManagerRegion` を空クラスに戻しても失敗が続いたのはこのため。routing ロジック自体は upstream と同一で正しい
+
+**修正内容**（ブランチ `betajp-braille-routing-fix`）:
+
+1. `source/braille.py` の `ReviewCursorManagerRegion` は upstream と同じ空クラスのまま（対応済みだった）
+2. `tests/unit/test_braille/test_routing.py` の `TestReviewRoutingMovesSystemCaretInNavigableText.setUp()` で upstream の既定テーブル `en-ueb-g1.ctb` を明示的に設定し、`tearDown()` で復元（JP PATCH コメント付き）
+3. 4 つの `@unittest.skip` を削除
+
+これにより 4 テストすべてがパスし、ユニットテストスイート全体（1172 件）もグリーン。以下は当時の調査記録として残す。
+
+---
+
 ## 問題の本質
 
 **結論**: **C) カスタムコードのバグ修正が必要**

--- a/tests/unit/test_braille/test_routing.py
+++ b/tests/unit/test_braille/test_routing.py
@@ -7,6 +7,7 @@
 
 import config
 import braille
+import brailleTables
 import textInfos
 import api
 import controlTypes
@@ -39,6 +40,15 @@ class TestReviewRoutingMovesSystemCaretInNavigableText(unittest.TestCase):
 	cm: CursorManager
 
 	def setUp(self):
+		# BEGIN JP PATCH
+		# nvdajp's default braille table is ja-jp-comp6.utb, which translates
+		# through the Japanese braille translator and inserts extra indicator
+		# cells for Latin text, so braille cell positions no longer map
+		# one-to-one to characters. These tests assume upstream's one-to-one
+		# mapping, so force upstream's default table while they run.
+		self._originalTable = braille.handler.table
+		braille.handler.table = brailleTables.getTable("en-ueb-g1.ctb")
+		# END JP PATCH
 		# Set tethering to review.
 		braille.handler.setTether(braille.TetherTo.REVIEW.value)
 		cmText = "the quick brown fox jumps over the lazy dog"
@@ -48,14 +58,12 @@ class TestReviewRoutingMovesSystemCaretInNavigableText(unittest.TestCase):
 		api.setReviewPosition(caret)
 		braille.handler.handleReviewMove()
 
-	@unittest.skip(
-		"See projectDocs/jp/archive/test-routing-failures.md for details. "
-		"Investigation revealed that even when ReviewCursorManagerRegion is reverted to upstream's "
-		"empty class implementation, these tests still fail in the nvdajp branch. This suggests "
-		"the issue may not be solely due to nvdajp-specific code, but could involve test "
-		"preconditions, environment differences, or other factors. These tests are temporarily "
-		"skipped pending further investigation.",
-	)
+	# BEGIN JP PATCH
+	def tearDown(self):
+		braille.handler.table = self._originalTable
+
+	# END JP PATCH
+
 	def test_moveCaret_never_moveReviewAndActivate(self):
 		"""Test that routing action on a cell will move the review cursor when routing changes the position,
 		whereas it should activate the current position when the review cursor is already at that position.
@@ -86,14 +94,6 @@ class TestReviewRoutingMovesSystemCaretInNavigableText(unittest.TestCase):
 		caret = self.cm.makeTextInfo(textInfos.POSITION_CARET)
 		self.assertEqual(caret, self.caret)
 
-	@unittest.skip(
-		"See projectDocs/jp/archive/test-routing-failures.md for details. "
-		"Investigation revealed that even when ReviewCursorManagerRegion is reverted to upstream's "
-		"empty class implementation, these tests still fail in the nvdajp branch. This suggests "
-		"the issue may not be solely due to nvdajp-specific code, but could involve test "
-		"preconditions, environment differences, or other factors. These tests are temporarily "
-		"skipped pending further investigation.",
-	)
 	def test_moveCaret_never_instantActivate(self):
 		"""Test that routing action on a cell will activate the current position
 		when the review cursor is already at that position.
@@ -113,14 +113,6 @@ class TestReviewRoutingMovesSystemCaretInNavigableText(unittest.TestCase):
 		caret = self.cm.makeTextInfo(textInfos.POSITION_CARET)
 		self.assertEqual(caret, self.caret)
 
-	@unittest.skip(
-		"See projectDocs/jp/archive/test-routing-failures.md for details. "
-		"Investigation revealed that even when ReviewCursorManagerRegion is reverted to upstream's "
-		"empty class implementation, these tests still fail in the nvdajp branch. This suggests "
-		"the issue may not be solely due to nvdajp-specific code, but could involve test "
-		"preconditions, environment differences, or other factors. These tests are temporarily "
-		"skipped pending further investigation.",
-	)
 	def test_moveCaret_always_moveReviewAndActivate(self):
 		"""Test that routing action on a cell will move the review cursor when routing changes the position,
 		whereas it should activate the current position when the review cursor is already at that position.
@@ -151,14 +143,6 @@ class TestReviewRoutingMovesSystemCaretInNavigableText(unittest.TestCase):
 		caret = self.cm.makeTextInfo(textInfos.POSITION_CARET)
 		self.assertEqual(caret, expectedReview)
 
-	@unittest.skip(
-		"See projectDocs/jp/archive/test-routing-failures.md for details. "
-		"Investigation revealed that even when ReviewCursorManagerRegion is reverted to upstream's "
-		"empty class implementation, these tests still fail in the nvdajp branch. This suggests "
-		"the issue may not be solely due to nvdajp-specific code, but could involve test "
-		"preconditions, environment differences, or other factors. These tests are temporarily "
-		"skipped pending further investigation.",
-	)
 	def test_moveCaret_always_instantActivate(self):
 		"""Test that routing action on a cell will activate the current position
 		when the review cursor is already at that position.


### PR DESCRIPTION
## 概要

`tests/unit/test_braille/test_routing.py` の `TestReviewRoutingMovesSystemCaretInNavigableText` でスキップされていた 4 テストのスキップを解除します。

## 根本原因

これまで「`ReviewCursorManagerRegion` を upstream と同じ空クラスに戻してもテストが失敗する」ため原因不明としてスキップされていましたが、調査の結果、**routing 実装のバグではなく点字テーブルの既定値の違い**が原因と判明しました。

- nvdajp は既定の点字テーブルを `en-ueb-g1.ctb` から `ja-jp-comp6.utb` に変更している（`source/config/configSpec.py`）
- `ja-jp-comp6.utb` の場合、`louisHelper.translate()` は liblouis ではなく日本語点訳エンジン（`synthDrivers.jtalk.translator2`）を経由する
- 日本語点訳エンジンはラテン文字テキストに外字符などの追加セルを挿入するため、点字セル位置と文字位置が 1 対 1 に対応しなくなる
- upstream のテストは「1 セル = 1 文字」のマッピングを前提としているため、`routeTo(3)` が文字位置 2 に解決される等のズレが生じて失敗していた

`source/braille.py` の routing ロジックは upstream と同一であり、修正は不要です。

## 変更内容

- `tests/unit/test_braille/test_routing.py`: `setUp()` で upstream の既定テーブル `en-ueb-g1.ctb` を明示設定し、`tearDown()` で復元（JP PATCH コメント付き）。4 つの `@unittest.skip` を削除
- `projectDocs/jp/braille-routing-analysis.md`: 解決内容を追記
- `projectDocs/jp/archive/test-routing-failures.md`: 解決済み注記を追加

## テスト

- `tests.unit.test_braille.test_routing`: 6 件すべてパス（スキップなし）
- `rununittests.bat`: 全 1172 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)