### PR TITLE
Update artifact actions to Node 24 versions

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -194,7 +194,7 @@ jobs:
       run: ci/scripts/tests/beforeTests.ps1
     # BEGIN JP PATCH (ship JTalk runtime separately from workspace cache to avoid stale dic propagation)
     - name: Upload JTalk runtime artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: JTalk runtime (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: |
@@ -341,7 +341,7 @@ jobs:
         fail-on-cache-miss: true
     # BEGIN JP PATCH (overwrite JTalk files from dedicated artifact after workspace cache restore)
     - name: Get JTalk runtime artifact
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: JTalk runtime (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: .
@@ -400,7 +400,7 @@ jobs:
         fail-on-cache-miss: true
     # BEGIN JP PATCH (overwrite JTalk files from dedicated artifact after workspace cache restore)
     - name: Get JTalk runtime artifact
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: JTalk runtime (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: .
@@ -423,7 +423,7 @@ jobs:
       run: ./jptools/runJpSmokeTests.ps1 -SkipInstall -SkipOverlay
     - name: Upload JP smoke test artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: JP smoke test results (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: |
@@ -494,7 +494,7 @@ jobs:
         fail-on-cache-miss: true
     # BEGIN JP PATCH (overwrite packaged JTalk files from dedicated artifact after workspace cache restore)
     - name: Get JTalk runtime artifact
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: JTalk runtime (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: .
@@ -729,7 +729,7 @@ jobs:
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v7
     - name: Get symbols
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: Symbols (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
         path: output


### PR DESCRIPTION
## 概要

CI に出ている deprecation warning への対応です:

> Warning: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v5.

（例: [run 28692494817](https://github.com/nvdajp/nvdajp/actions/runs/28692494817/job/85096224423)）

## 内容

`testAndPublish.yml` 内で artifact 系アクションのバージョンが混在していたため、既に大半で使われている最新版（Node 24 宣言）に統一しました：

| 箇所 | 変更前 | 変更後 |
|---|---|---|
| Upload JTalk runtime artifact（JP PATCH、warning の発生源） | `upload-artifact@v5` | `@v7` |
| Upload JP smoke test artifacts（JP PATCH、失敗時のみ） | `upload-artifact@v4` | `@v7` |
| download 3箇所 | `download-artifact@v6` | `@v8` |
| Get symbols（Mozilla シンボルアップロード用） | `download-artifact@v4` | `@v8` |

古い pin は主に JP パッチ部分に残っていたもので、本家追従時に置き去りになったと見られます。

## 補足

- `upload-artifact@v7.0.1` / `download-artifact@v8` が `runs: using: 'node24'` を宣言していることを GitHub API で確認済み。
- v4 以降の artifact は世代間で相互互換で、現行 workflow でも upload@v5 → download@v6 等の組み合わせで動作しているため、動作上の変更はありません（warning が消えるだけ）。
- YAML の構文検証済み。実際の CI 動作はこの PR の checks で確認できます。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>