### PR TITLE
Speak a CRLF pair as a single newline character (#113)

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1810,6 +1810,15 @@ def getTextInfoSpeech(  # noqa: C901
 		firstField = textWithFields[0]
 		if isinstance(firstField, str):
 			firstText = firstField.strip() if not firstField.isspace() else firstField
+	# BEGIN JP PATCH
+	# nvdajp #113: Scintilla controls (Notepad++ etc.) treat CRLF as one
+	# caret position, so the character/word unit text can be exactly
+	# "\r\n" (two characters). That fell through to the plain text path
+	# and was announced as "blank". Treat the pair as a single newline
+	# character so it is spoken the same way as "\n" in LF-only documents.
+	if isWordOrCharUnit and firstText == "\r\n":
+		textWithFields[0] = firstText = "\n"
+	# END JP PATCH
 	if onlyInitialFields or (
 		isWordOrCharUnit
 		and (len(firstText) == 1 or len(unicodeNormalize(firstText)) == 1)

--- a/tests/unit/test_jpSpeechCrlfCharacter.py
+++ b/tests/unit/test_jpSpeechCrlfCharacter.py
@@ -1,0 +1,85 @@
+# -*- coding: UTF-8 -*-
+# tests/unit/test_jpSpeechCrlfCharacter.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited, NVDA Japanese Team
+
+"""Unit tests for speaking a CRLF pair as a single newline character.
+
+Scintilla controls (Notepad++ etc.) treat CRLF as one caret position,
+so the character unit at a line break yields the two-character text
+"\\r\\n". Without the JP patch in speech.getTextInfoSpeech this fell
+through to the plain text path and was announced as "blank".
+See nvdajp issue #113.
+"""
+
+import unittest
+
+import textInfos
+from controlTypes import OutputReason
+
+from .textProvider import BasicTextInfo, BasicTextProvider
+
+
+class CrlfTextInfo(BasicTextInfo):
+	"""Mimics Scintilla: a CRLF pair is a single character unit."""
+
+	def _getCharacterOffsets(self, offset):
+		storyText = self._getStoryText()
+		if storyText[offset : offset + 2] == "\r\n":
+			return [offset, offset + 2]
+		return super()._getCharacterOffsets(offset)
+
+
+class CrlfTextProvider(BasicTextProvider):
+	def makeTextInfo(self, position):
+		ti = super().makeTextInfo(position)
+		ti.__class__ = CrlfTextInfo
+		return ti
+
+
+class TestCrlfCharacterSpeech(unittest.TestCase):
+	def setUp(self):
+		import speechDictHandler
+
+		speechDictHandler.initialize()  # setting the synth depends on dictionary["voice"]
+		import synthDriverHandler
+
+		assert synthDriverHandler.setSynth("silence")
+		assert synthDriverHandler.getSynth()
+		from speech import speechInitialize
+
+		speechInitialize()
+
+	def _getCharacterSpeech(self, text: str, offset: int) -> str:
+		from speech.speech import getTextInfoSpeech
+
+		obj = CrlfTextProvider(text=text, selection=(offset, offset))
+		info = obj.makeTextInfo(textInfos.POSITION_SELECTION)
+		info.expand(textInfos.UNIT_CHARACTER)
+		sequences = list(
+			getTextInfoSpeech(
+				info,
+				unit=textInfos.UNIT_CHARACTER,
+				reason=OutputReason.CARET,
+			),
+		)
+		return " ".join(item for seq in sequences for item in seq if isinstance(item, str))
+
+	def test_crlfPairSpokenAsNewline(self):
+		"""The two-character "\\r\\n" unit must be spoken like a newline, not as blank."""
+		spoken = self._getCharacterSpeech("a\r\nb", 1)
+		self.assertNotIn("blank", spoken)
+		self.assertIn("line feed", spoken)
+
+	def test_lfOnlySpokenAsNewline(self):
+		"""Regression guard: a single "\\n" character keeps its symbol reading."""
+		spoken = self._getCharacterSpeech("a\nb", 1)
+		self.assertNotIn("blank", spoken)
+		self.assertIn("line feed", spoken)
+
+	def test_normalCharacterUnaffected(self):
+		spoken = self._getCharacterSpeech("a\r\nb", 0)
+		self.assertIn("a", spoken)
+		self.assertNotIn("line feed", spoken)


### PR DESCRIPTION
## 概要

Notepad++（Scintilla 系エディタ）で CRLF の改行にカーソルを移動すると「ブランク」と読まれる問題を修正します。

Fixes #113

## 原因（コード上で機構を特定・テストで実証済み）

1. Scintilla は CRLF を1つのキャレット位置として扱うため、改行上の文字単位テキストが `"\r\n"`（2文字）になる（`scintilla.py` の `_getCharacterOffsets` は `SCI_POSITIONAFTER` を使用）。
2. `speech.getTextInfoSpeech` の1文字読み（記号読み）経路は `len(firstText) == 1` のときだけ発動する。
3. 2文字の `"\r\n"` は通常テキスト読みに落ち、空白のみのため `isBlank()` により「ブランク」になる。

LF/CR 単独のファイルでは1文字ユニットになり正しく読まれる — issue の備考（改行コードを LF/CR に変えると読める）と完全に一致します。

## 修正

`getTextInfoSpeech` で、文字/単語単位のテキストがちょうど `"\r\n"` の場合に `"\n"` として扱う JP パッチを追加（`# BEGIN JP PATCH` マーカー付き）。LF ファイルと同じ改行の記号読み（日本語では「カイギョウ」、`locale/ja/symbols.dic` に定義済み）になります。

Scintilla 側で文字単位を `\r` だけに縮める案は、選択・点字のユニット整合に影響しうるため採りませんでした。この修正は upstream にも提案可能な内容です。

## テスト

新規 `tests/unit/test_jpSpeechCrlfCharacter.py`（3ケース）:

- Scintilla の挙動（CRLF ペアを1文字単位として返す TextInfo）を模した fake で `getTextInfoSpeech` を直接検証
- **修正なしでは主ケースが `'blank' unexpectedly found in 'blank'` で失敗することを確認済み**（= 報告症状の再現）、修正ありで3件合格
- 回帰ガード: LF 単独の読み、通常文字の読みが不変であることも検証

その他:

- `test_cursorManager.py`: OK
- `test_speech*.py`: 既存の2件の失敗（`SpeechExtensionPoints` 系）がありますが、**修正前のクリーンツリーでも同一に失敗する既存問題**で、本PRとは無関係です
- ruff check: 合格（format 差分は既存 JP パッチ由来のもののみで、本PRのハンクはクリーン）

## 実機確認のお願い

Notepad++（CRLF のファイル）で左矢印により改行へ移動したとき「カイギョウ」と読まれることをご確認ください。LF/CR ファイルでの読みが従来どおりであることも併せて確認いただけると安心です。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>