### PR TITLE
OCR結果の日本語文字間にスペースが入るリグレッションを修正 (#683)

### DIFF
--- a/projectDocs/jp/changes-nvdajp.md
+++ b/projectDocs/jp/changes-nvdajp.md
@@ -607,14 +607,15 @@ def buildConfigH(target, source, env):
 
 #### 6.7 コンテンツ認識の日本語文字処理
 
-`source/contentRecog/__init__.py` に、東アジア幅（East Asian Width）が狭い文字（Narrow）の処理を追加しました。
+`source/contentRecog/__init__.py` に、東アジア幅（East Asian Width）に基づく単語区切りの処理を追加しました。
 
-* **目的**: OCR などのコンテンツ認識結果で、東アジア幅が狭い文字（半角文字など）の間に不要なスペースを挿入しないようにする
+* **目的**: OCR などのコンテンツ認識結果で、日本語（東アジア幅が Wide/Fullwidth の文字）の単語間に不要なスペースを挿入しないようにする。スペースを挿入するのは、前の単語の末尾と次の単語の先頭がともに東アジア幅が狭い文字（Narrow、半角英数など）の場合のみ
 * **背景**: 2025.3jp では存在していた機能で、2026.1 のマージ時に削除されていたものを追加
 * **実装**:
   * `unicodedata.east_asian_width` のインポートを追加
   * `isEastAsianNarrow(c)`、`startsWithEastAsianNarrow(s)`、`endsWithEastAsianNarrow(s)` 関数を追加
-  * `LinesWordsResult._parseData()` メソッドで、前の単語の末尾と次の単語の先頭がともに東アジア幅が狭い文字の場合、スペースを挿入しないように条件分岐を追加
+  * `LinesWordsResult._parseData()` メソッドで、前の単語の末尾と次の単語の先頭がともに東アジア幅が狭い文字の場合のみスペースを挿入する条件分岐を追加
+* **注意**: 2026.1 マージ時の復元でこの条件分岐が逆転し（Narrow 同士でスペースを抑制し、日本語の文字間にスペースを挿入）、issue #683「OCR時に日本語の文字間にスペースが入る」のリグレッションが発生していた。2026-07-05 に 2025.3jp のロジックへ修正し、日本語ケースのユニットテスト（`TestLinesWordsResultEastAsianWide`）を追加した
 
 #### 6.8 編集可能テキストでの改行報告
 

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -267,19 +267,19 @@ class LinesWordsResult(RecognitionResult):
 				if firstWordOfLine:
 					firstWordOfLine = False
 				# BEGIN JP PATCH
-				# nvdajp: don't add space between East Asian narrow characters
+				# nvdajp: separate words with a space only when both sides are
+				# East Asian narrow characters (e.g. Latin words). East Asian
+				# wide characters such as Japanese kana and kanji must be
+				# joined without a space (#683).
 				elif (
 					self._textList
 					and endsWithEastAsianNarrow(self._textList[-1])
 					and startsWithEastAsianNarrow(word["text"])
 				):
-					# Don't separate with a space for East Asian narrow characters.
-					pass
-				# END JP PATCH
-				else:
 					# Separate with a space.
 					self._textList.append(" ")
 					self.textLen += 1
+				# END JP PATCH
 				self.words.append(
 					LwrWord(
 						self.textLen,

--- a/tests/unit/contentRecog/test_contentRecog.py
+++ b/tests/unit/contentRecog/test_contentRecog.py
@@ -70,27 +70,24 @@ class TestLinesWordsResult(unittest.TestCase):
 		],
 	]
 	TOP = 0
-	# BEGIN JP PATCH
-	# nvdajp: East Asian narrow characters don't have spaces between them
-	BOTTOM = 21
-	WORD1_OFFSETS = (0, 5)
+	BOTTOM = 23
+	WORD1_OFFSETS = (0, 6)
 	WORD1_SECOND = 1
-	WORD1_LAST = 4
+	WORD1_LAST = 5
 	WORD1_RECT = RectLTWH(100, 200, 10, 20)
-	WORD2_START = 5
-	WORD2_OFFSETS = (5, 11)
+	WORD2_START = 6
+	WORD2_OFFSETS = (6, 12)
 	WORD2_RECT = RectLTWH(110, 200, 10, 20)
-	WORD3_OFFSETS = (11, 16)
-	WORD3_START = 11
+	WORD3_OFFSETS = (12, 18)
+	WORD3_START = 12
 	WORD3_RECT = RectLTWH(100, 220, 10, 20)
-	WORD4_OFFSETS = (16, 22)
+	WORD4_OFFSETS = (18, 24)
 	WORD4_RECT = RectLTWH(110, 220, 10, 20)
-	LINE1_OFFSETS = (0, 11)
+	LINE1_OFFSETS = (0, 12)
 	LINE1_SECOND = 1
-	LINE1_LAST = 10
-	LINE2_OFFSETS = (11, 22)
-	LINE2_START = 11
-	# END JP PATCH
+	LINE1_LAST = 11
+	LINE2_OFFSETS = (12, 24)
+	LINE2_START = 12
 
 	def setUp(self):
 		info = contentRecog.RecogImageInfo(0, 0, 1000, 2000, 1)
@@ -99,10 +96,7 @@ class TestLinesWordsResult(unittest.TestCase):
 		self.textInfo = self.result.makeTextInfo(self.fakeObj, textInfos.POSITION_FIRST)
 
 	def test_text(self):
-		# BEGIN JP PATCH
-		# nvdajp: East Asian narrow characters don't have spaces between them
-		self.assertEqual(self.result.text, "word1word2\nword3word4\n")
-		# END JP PATCH
+		self.assertEqual(self.result.text, "word1 word2\nword3 word4\n")
 
 	def test_textLen(self):
 		self.assertEqual(self.result.textLen, len(self.result.text))
@@ -178,3 +172,39 @@ class TestLinesWordsResult(unittest.TestCase):
 	def test_copyTextInfo(self):
 		copy = self.textInfo.copy()
 		self.assertEqual(copy, self.textInfo)
+
+
+# BEGIN JP PATCH
+class TestLinesWordsResultEastAsianWide(unittest.TestCase):
+	"""East Asian wide characters must be joined without spaces (#683).
+
+	Windows OCR reports each Japanese character or short run as a
+	separate word; separating them with spaces would make the result
+	unreadable. A space is inserted only between two East Asian narrow
+	characters (e.g. between Latin words).
+	"""
+
+	DATA = [
+		[
+			{"x": 100, "y": 200, "width": 10, "height": 20, "text": "こんにちは"},
+			{"x": 110, "y": 200, "width": 10, "height": 20, "text": "世界"},
+		],
+		[
+			{"x": 100, "y": 220, "width": 10, "height": 20, "text": "あいう"},
+			{"x": 110, "y": 220, "width": 10, "height": 20, "text": "word"},
+			{"x": 120, "y": 220, "width": 10, "height": 20, "text": "えお"},
+		],
+	]
+
+	def setUp(self):
+		info = contentRecog.RecogImageInfo(0, 0, 1000, 2000, 1)
+		self.result = contentRecog.LinesWordsResult(self.DATA, info)
+
+	def test_text(self):
+		self.assertEqual(self.result.text, "こんにちは世界\nあいうwordえお\n")
+
+	def test_textLen(self):
+		self.assertEqual(self.result.textLen, len(self.result.text))
+
+
+# END JP PATCH


### PR DESCRIPTION
Fixes #683

## 原因

`LinesWordsResult._parseData` の JP パッチ（東アジア幅に基づく単語区切り）が、2026.1 マージ時の復元（9fb3415348）で**分岐が逆転**していました。

- **2025.3jp（正）**: 前の単語の末尾と次の単語の先頭がともに East Asian Narrow（半角英数など）の場合**のみ**スペースを挿入。日本語（Wide）はスペースなしで連結。
- **2026.1jp（誤）**: Narrow 同士の場合にスペースを**抑制**し、それ以外（日本語）にスペースを挿入 → 報告どおり `こ ん に ち は` になり、逆に英単語同士は `word1word2` と連結されていた。

ユニットテストも逆転した実装に合わせて `word1word2` を期待するよう書き換えられていたため、CI では検出できませんでした。復元の参照元だった `changes-nvdajp.md` 6.7 節の説明自体も逆に書かれていました。

## 変更内容

- `source/contentRecog/__init__.py`: 2025.3jp のロジックに復元（Narrow 同士のみスペース挿入、それ以外は連結）。
- `tests/unit/contentRecog/test_contentRecog.py`: 既存テストの期待値を本家と同一（`word1 word2`）に復元し、JP パッチ範囲を縮小。日本語・日英混在行の回帰テスト `TestLinesWordsResultEastAsianWide` を追加（`こんにちは世界` / `あいうwordえお`）。
- `projectDocs/jp/changes-nvdajp.md`: 6.7 節の誤った説明を修正し、本リグレッションの経緯を追記。

## テスト

- `tests.unit.contentRecog.test_contentRecog` 26件（本家24 + JP 2）すべてパス。
- `ruff format --check` / `ruff check` パス。

## 実機確認のお願い

Windows OCR ランタイムを伴う NVDA+R の実機確認は未実施です。2026.1.1jp で再現していた環境で、本ブランチのビルドによる確認をお願いします。