### PR TITLE
Bump prebuilt JTalk dictionary pin to libkuraji-jtalk-dic v1.1.0

### DIFF
--- a/miscDepsJp/include/libkuraji/tests/mecabHarness.json
+++ b/miscDepsJp/include/libkuraji/tests/mecabHarness.json
@@ -2164,7 +2164,7 @@
     },
     {
         "text": "roma2kana",
-        "speech": "ロマニカナ"
+        "speech": "ロウマニカナ"
     },
     {
         "text": "2kana",

--- a/miscDepsJp/jptools/jtalk-dic-version.txt
+++ b/miscDepsJp/jptools/jtalk-dic-version.txt
@@ -3,10 +3,10 @@
 # nishimotz/libkuraji-jtalk-dic release.
 # See projectDocs/jp/vendor-submodules.md ("辞書のビルド時取得（方針転換）").
 repo=nishimotz/libkuraji-jtalk-dic
-tag=v1.0.4
-asset=jtalk-dic-v1.0.4.zip
-sha256=a303268e2abf69e9c0db9286ec5abb70882b60e5e0621ae576e505563b652ed3
+tag=v1.1.0
+asset=jtalk-dic-v1.1.0.zip
+sha256=419e660ae8540e650b1b1e5aa070d6d149d5ac8c29b65398cc7778582080d107
 # mecab-dict-index.exe: used by build_userdic.py to compile jtusr.dic
 # (the user dictionary). Unsigned executable; verified via checksum before use.
-tool_asset=mecab-dict-index-v1.0.4.exe
-tool_sha256=ff62bc4cd3ef7b1a2459a091b3ffefadfd281e658e811dca7eed852505be25a7
+tool_asset=mecab-dict-index-v1.1.0.exe
+tool_sha256=9c2b744dfcb1b5b17bc43666216f140244fa53b784e32968a5e15fe01bea9702


### PR DESCRIPTION
## Summary

Bumps the pinned prebuilt JTalk dictionary (`jtalkDicSource=prebuilt`, the
default) from `libkuraji-jtalk-dic` v1.0.4 to v1.1.0.

The main change in v1.1.0 is a new `nvdajp-eng-dic` (English word
readings for JTalk speech / libkuraji braille), generated from CMUdict
(permissive license) instead of the GPL-only `bep-eng.dic` that this
repository's own build uses. See
[nishimotz/libkuraji-jtalk-dic#1](https://github.com/nishimotz/libkuraji-jtalk-dic/pull/1)
for the source-side change.

English pronunciation from this new dictionary is approximate (rule-based
ARPAbet→kana conversion) and will not always match `bep-eng.dic`'s
readings exactly. This is an accepted tradeoff, not a regression target -
see validation below.

## Validation done locally before this PR

- **libkuraji real-dictionary integration tests** (`tests/test_integration.py`,
  `LIBKURAJI_INTEGRATION=1`, against a local build of the new dictionary
  via `LIBKURAJI_JTALK_DIC_DIR`): 2219/2219 word-separation-family tests
  pass. (`test_mecab_fixture_parity` intentionally fails - it byte-compares
  against a fixture recorded against the *old* dictionary version, and is
  expected to be re-recorded separately.)
- **This repo's JTalk/MeCab smoke tests** (`miscDepsJp/jptools/test.py`,
  with the new dictionary swapped into `source/synthDrivers/jtalk/dic`):
  - `JtalkTests` (actual TTS pipeline) and `JpBrailleTests`: all pass.
  - `MecabTests.test_user_dic_applied`: passes.
  - `MecabTests.test_all` (harness.json regression corpus): 1 remaining
    mismatch, `roma2kana`, a pronunciation-only difference (no braille/
    segmentation change) caused by "roma"/"kana" now resolving as genuine
    English dictionary words. Accepted.
  - Two earlier-round regressions were found and fixed upstream before
    this pin bump: short function words (e.g. "i" breaking "iモード" into
    "i モード") and Japanese place names (e.g. "kyoto" shadowing the
    existing romaji-reading fallback) were excluded from the bulk word
    list - see the libkuraji-jtalk-dic PR for detail.

## Test plan

- [ ] CI: Build NVDA and confirm no build failures
- [ ] CI: jp-specific test jobs (MecabTests/JtalkTests/JpBrailleTests) green
