### PR TITLE
Restore default capPitchChange to 0 for Japanese version (#695)

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -65,7 +65,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	useWASAPIForSAPI4 = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 
 	[[__many__]]
-		capPitchChange = integer(default=30,min=-100,max=100)
+		capPitchChange = integer(default=0,min=-100,max=100) # was default=30 (nvdajp)
 		sayCapForCapitals = boolean(default=false)
 		beepForCapitals = boolean(default=false)
 		useSpellingFunctionality = boolean(default=true)


### PR DESCRIPTION
Fixes #695. Restores the default value of capPitchChange to 0 for Japanese NVDA, which was reset to 30 during the recent upstream merge.