### PR TITLE
Fix JTalk dictionary version logging TypeError and log version on jtalkDriver initialization

### DIFF
--- a/source/synthDrivers/jtalk/mecab.py
+++ b/source/synthDrivers/jtalk/mecab.py
@@ -294,16 +294,23 @@ def Mecab_initialize(
 				f"{_mecab_config} -> {requested_config}",
 			)
 		Mecab_terminate(logwrite_)
-	if mecab is None:
-		# libmc is guaranteed to be initialized at this point (asserted above)
-		assert libmc is not None  # Type narrowing for type checkers
-		if logwrite_:
-			logwrite_("dic: %s" % dic)
+	# Always print/log the version and dictionary info if logwrite_ is provided,
+	# even if mecab is already initialized.
+	if logwrite_:
+		logwrite_("dic: %s" % dic)
 		try:
 			dic_version_path = Path(dic) / "DIC_VERSION"
 			s = dic_version_path.read_text(encoding="utf-8").strip()
-			if logwrite_:
-				logwrite_("mecab:" + libmc.mecab_version() + " " + s)
+			version_str = libmc.mecab_version().decode("utf-8", "ignore")
+			logwrite_("mecab:" + version_str + " " + s)
+		except Exception:
+			pass
+	if mecab is None:
+		# libmc is guaranteed to be initialized at this point (asserted above)
+		assert libmc is not None  # Type narrowing for type checkers
+		try:
+			dic_version_path = Path(dic) / "DIC_VERSION"
+			s = dic_version_path.read_text(encoding="utf-8").strip()
 			# check utf-8 dictionary
 			if CODE not in s:
 				raise RuntimeError("utf-8 dictionary for mecab required.")


### PR DESCRIPTION
Follow-up of #694. Decodes the MeCab version bytes object to a UTF-8 string before logging to prevent a silent TypeError, and extracts the logging logic so it runs on every Mecab_initialize call if logwrite is active (e.g. when jtalkDriver initializes later in startup).