### PR TITLE
WIP: alphajp CI に Azure Key Vault signing (OIDC) 対応を追加

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -224,7 +224,8 @@ jobs:
       shell: pwsh
       run: |
         $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
-        Write-Output "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
+        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Run synthDriverHost32 runtime builder with its own Python
       shell: pwsh
@@ -593,7 +594,8 @@ jobs:
       shell: pwsh
       run: |
         $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
-        Write-Output "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
+        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Build scons docs targets
       shell: cmd

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -85,8 +85,8 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
-      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable)
-      AZURE_KV_SIGNING: ${{ vars.AZURE_KV_SIGNING }}
+      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, push/workflow_dispatch only)
+      AZURE_KV_SIGNING: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && vars.AZURE_KV_SIGNING || '' }}
       # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.
@@ -543,8 +543,8 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
-      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable)
-      AZURE_KV_SIGNING: ${{ vars.AZURE_KV_SIGNING }}
+      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, push/workflow_dispatch only)
+      AZURE_KV_SIGNING: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && vars.AZURE_KV_SIGNING || '' }}
       # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -215,14 +215,6 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-    - name: Set Azure Key Vault access token
-      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-      shell: pwsh
-      run: |
-        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
-        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
-        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Prepare source code
       shell: cmd
@@ -588,14 +580,6 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-    - name: Set Azure Key Vault access token
-      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-      shell: pwsh
-      run: |
-        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
-        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
-        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Build scons docs targets
       shell: cmd

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -77,6 +77,7 @@ jobs:
     permissions:
       contents: read
       actions: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +85,9 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
+      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable)
+      AZURE_KV_SIGNING: ${{ vars.AZURE_KV_SIGNING }}
+      # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.
       # This is not a problem for these variables as they should be the same across jobs.
@@ -206,6 +210,13 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Set Azure Key Vault access token
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      shell: pwsh
+      run: |
+        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
+        Write-Output "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Run synthDriverHost32 runtime builder with its own Python
       shell: pwsh
@@ -515,6 +526,7 @@ jobs:
     permissions:
       contents: read
       actions: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -522,6 +534,9 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
+      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable)
+      AZURE_KV_SIGNING: ${{ vars.AZURE_KV_SIGNING }}
+      # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.
       # So we only set the output variables for the default architecture.
@@ -556,6 +571,22 @@ jobs:
       run: ci/scripts/setSconsArgs.ps1
       env:
         apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
+    # BEGIN JP PATCH (Azure Key Vault signing with OIDC)
+    - name: Login to Azure for Key Vault signing
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Set Azure Key Vault access token
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      shell: pwsh
+      run: |
+        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
+        Write-Output "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    # END JP PATCH
     - name: Build scons docs targets
       shell: cmd
       run: scons %sconsDocsOutTargets% %sconsArgs% %sconsCores%

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -204,7 +204,7 @@ jobs:
       if: ${{ env.AZURE_KV_SIGNING == '1' }}
       shell: pwsh
       run: |
-        dotnet tool install --global AzureSignTool
+        dotnet tool install --global AzureSignTool --version 7.0.1
         Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     # END JP PATCH
     # BEGIN JP PATCH (Azure Key Vault signing with OIDC - push/workflow_dispatch only)
@@ -617,7 +617,7 @@ jobs:
       if: ${{ env.AZURE_KV_SIGNING == '1' }}
       shell: pwsh
       run: |
-        dotnet tool install --global AzureSignTool
+        dotnet tool install --global AzureSignTool --version 7.0.1
         Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     # END JP PATCH
     - name: Build NVDAController client

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -215,6 +215,15 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Set Azure Key Vault access token
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      shell: pwsh
+      run: |
+        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
+        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
+        Write-Host "::add-mask::$token"
+        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Prepare source code
       shell: cmd
@@ -580,6 +589,15 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Set Azure Key Vault access token
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      shell: pwsh
+      run: |
+        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
+        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
+        Write-Host "::add-mask::$token"
+        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Build scons docs targets
       shell: cmd

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -207,9 +207,6 @@ jobs:
         dotnet tool install --global AzureSignTool
         Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     # END JP PATCH
-    - name: Prepare source code
-      shell: cmd
-      run: scons source %sconsArgs% %sconsCores%
     # BEGIN JP PATCH (Azure Key Vault signing with OIDC)
     - name: Login to Azure for Key Vault signing
       if: ${{ env.AZURE_KV_SIGNING == '1' }}
@@ -227,6 +224,9 @@ jobs:
         if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
         "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
+    - name: Prepare source code
+      shell: cmd
+      run: scons source %sconsArgs% %sconsCores%
     - name: Run synthDriverHost32 runtime builder with its own Python
       shell: pwsh
       env:

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -198,6 +198,15 @@ jobs:
     - name: Prepare source code
       shell: cmd
       run: scons source %sconsArgs% %sconsCores%
+    # BEGIN JP PATCH (Azure Key Vault signing with OIDC)
+    - name: Login to Azure for Key Vault signing
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    # END JP PATCH
     - name: Run synthDriverHost32 runtime builder with its own Python
       shell: pwsh
       env:

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -207,9 +207,9 @@ jobs:
         dotnet tool install --global AzureSignTool
         Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     # END JP PATCH
-    # BEGIN JP PATCH (Azure Key Vault signing with OIDC)
+    # BEGIN JP PATCH (Azure Key Vault signing with OIDC - push/workflow_dispatch only)
     - name: Login to Azure for Key Vault signing
-      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
       uses: azure/login@v2
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -217,7 +217,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Set Azure Key Vault access token
-      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
       shell: pwsh
       run: |
         $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
@@ -580,9 +580,9 @@ jobs:
       run: ci/scripts/setSconsArgs.ps1
       env:
         apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
-    # BEGIN JP PATCH (Azure Key Vault signing with OIDC)
+    # BEGIN JP PATCH (Azure Key Vault signing with OIDC - push/workflow_dispatch only)
     - name: Login to Azure for Key Vault signing
-      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
       uses: azure/login@v2
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -590,7 +590,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Set Azure Key Vault access token
-      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
       shell: pwsh
       run: |
         $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -199,6 +199,14 @@ jobs:
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
+    # BEGIN JP PATCH (install AzureSignTool before Azure KV signing)
+    - name: Install AzureSignTool
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      shell: pwsh
+      run: |
+        dotnet tool install --global AzureSignTool
+        Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # END JP PATCH
     - name: Prepare source code
       shell: cmd
       run: scons source %sconsArgs% %sconsCores%
@@ -600,6 +608,14 @@ jobs:
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
+    # BEGIN JP PATCH (install AzureSignTool before Azure KV signing)
+    - name: Install AzureSignTool
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      shell: pwsh
+      run: |
+        dotnet tool install --global AzureSignTool
+        Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # END JP PATCH
     - name: Build NVDAController client
       shell: cmd
       run: scons client %sconsArgs% %sconsCores%

--- a/ci/scripts/signAzureKV.ps1
+++ b/ci/scripts/signAzureKV.ps1
@@ -137,6 +137,9 @@ function Get-KeyVaultAccessToken {
         try {
             $token = & $az.Source account get-access-token --resource https://vault.azure.net --query accessToken -o tsv 2>$null
             if ($LASTEXITCODE -eq 0 -and $token) {
+                if ($env:GITHUB_ACTIONS -eq "true") {
+                    Write-Host "::add-mask::$token"
+                }
                 return $token.Trim()
             }
         } catch {

--- a/ci/scripts/signAzureKV.ps1
+++ b/ci/scripts/signAzureKV.ps1
@@ -146,15 +146,11 @@ function Get-KeyVaultAccessToken {
             Write-Warning "az account get-access-token failed: $_"
         }
     }
-    if ($env:AZURE_CLIENT_SECRET -and $env:AZURE_CLIENT_ID -and $env:AZURE_TENANT_ID) {
-        return $null
-    }
     throw @"
 Azure Key Vault signing credentials are not available.
 Set one of:
   - AZURE_KV_ACCESS_TOKEN
   - az login (Azure CLI session)
-  - AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 "@
 }
 

--- a/ci/scripts/signAzureKV.ps1
+++ b/ci/scripts/signAzureKV.ps1
@@ -134,9 +134,13 @@ function Get-KeyVaultAccessToken {
     }
     $az = Get-Command az -ErrorAction SilentlyContinue
     if ($az) {
-        $token = az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv 2>$null
-        if ($LASTEXITCODE -eq 0 -and $token) {
-            return $token.Trim()
+        try {
+            $token = & $az.Source account get-access-token --resource https://vault.azure.net --query accessToken -o tsv 2>$null
+            if ($LASTEXITCODE -eq 0 -and $token) {
+                return $token.Trim()
+            }
+        } catch {
+            Write-Warning "az account get-access-token failed: $_"
         }
     }
     if ($env:AZURE_CLIENT_SECRET -and $env:AZURE_CLIENT_ID -and $env:AZURE_TENANT_ID) {


### PR DESCRIPTION
## 概要

alphajp ブランチの CI に Azure Key Vault (GlobalSign HSM) によるコード署名のための OIDC ログインを追加します。

## 現状

- sconstruct は AZURE_KV_SIGNING=1 で Azure Key Vault 署名を実行可能
- ci/scripts/signAzureKV.ps1 は OIDC トークン (AZURE_KV_ACCESS_TOKEN) に対応済み
- GitHub Actions 側で Azure OIDC login とトークン取得がまだ設定されていない
- SignPath ステップは workflow 上は残したまま、API_SIGNING_TOKEN secret を空にすることで動作しない前提とする

## この PR で追加するもの

- [x] buildNVDA ジョブに azure/login@v2 ステップを追加
- [x] buildNVDA ジョブの permissions に id-token: write を追加
- [x] buildNVDA ジョブに AZURE_KV_ACCESS_TOKEN 取得ステップを追加
- [x] createLauncher ジョブにも同様の Azure login/token 取得を追加
- [x] createLauncher ジョブの permissions に id-token: write を追加
- [x] AZURE_KV_SIGNING=1 を repository variables または env に設定
- [ ] GitHub Secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
- [ ] Azure 側で Federated credential (GitHub repo + environment) を設定
- [ ] AZURE_KV_SIGNING=1 の repository variable を設定
- [ ] API_SIGNING_TOKEN secret を空にして SignPath を無効化

## 注意

- この PR はまだ完成していません。WIP として GitHub/Azure の設定を進めながら実装を固めます。
- SignPath ステップは workflow 上は削除せず、API_SIGNING_TOKEN を空にすることで実質的に無効化します。Azure KV signing が安定した後、別 PR で削除を検討します。
