### PR TITLE
ci(betajp): add Azure Key Vault OIDC signing

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -122,6 +122,15 @@ jobs:
       run: ci/scripts/setSconsArgs.ps1
       env:
         apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
+    - name: Install signPath
+      env:
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
+      if: ${{ env.apiSigningToken }}
+      shell: cmd
+      run: |
+        PowerShell -Command "Set-ExecutionPolicy Bypass"
+        PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
+        PowerShell -Command "Install-Module -Name SignPath -Force"
     - name: Set cache key for SCons MSVC Cache
       shell: bash
       run: echo "SCONS_CACHE_KEY=${RUNNER_OS}-${ImageVersion}" >> $GITHUB_ENV
@@ -557,9 +566,6 @@ jobs:
       run: ci/scripts/setSconsArgs.ps1
       env:
         apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
-    - name: Build scons docs targets
-      shell: cmd
-      run: scons %sconsDocsOutTargets% %sconsArgs% %sconsCores%
     # Run launcher separately as we can't safely generate that in parallel to docs scons targets (#18867)
     # BEGIN JP PATCH (install AzureSignTool before Azure KV signing)
     - name: Install AzureSignTool
@@ -569,6 +575,9 @@ jobs:
         dotnet tool install --global AzureSignTool --version 7.0.1
         Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     # END JP PATCH
+    - name: Build scons docs targets
+      shell: cmd
+      run: scons %sconsDocsOutTargets% %sconsArgs% %sconsCores%
     # BEGIN JP PATCH (Azure Key Vault signing with OIDC - push/workflow_dispatch only)
     - name: Login to Azure for Key Vault signing
       if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
@@ -587,6 +596,15 @@ jobs:
         Write-Host "::add-mask::$token"
         "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
+    - name: Install signpath
+      env:
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
+      if: ${{ env.apiSigningToken }}
+      shell: cmd
+      run: |
+        PowerShell -Command "Set-ExecutionPolicy Bypass"
+        PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
+        PowerShell -Command "Install-Module -Name SignPath -Force"
     - name: Create launcher and controller client
       shell: cmd
       run: |

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -73,6 +73,11 @@ jobs:
     name: Build NVDA
     needs: matrix
     runs-on: ${{ needs.matrix.outputs.defaultRunner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +85,9 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
+      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, push/workflow_dispatch only)
+      AZURE_KV_SIGNING: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && vars.AZURE_KV_SIGNING || '' }}
+      # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.
       # This is not a problem for these variables as they should be the same across jobs.
@@ -112,6 +120,8 @@ jobs:
       run: ci/scripts/setBuildVersionVars.ps1
     - name: Set scons args
       run: ci/scripts/setSconsArgs.ps1
+      env:
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
     - name: Set cache key for SCons MSVC Cache
       shell: bash
       run: echo "SCONS_CACHE_KEY=${RUNNER_OS}-${ImageVersion}" >> $GITHUB_ENV
@@ -179,6 +189,32 @@ jobs:
         PYTHONIOENCODING: "utf-8"
       run: powershell -ExecutionPolicy Bypass -File jptools/verifyJtalkDictionary.ps1 -Strict
       # END JP PATCH
+    # END JP PATCH
+    # BEGIN JP PATCH (install AzureSignTool before Azure KV signing)
+    - name: Install AzureSignTool
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      shell: pwsh
+      run: |
+        dotnet tool install --global AzureSignTool --version 7.0.1
+        Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # END JP PATCH
+    # BEGIN JP PATCH (Azure Key Vault signing with OIDC - push/workflow_dispatch only)
+    - name: Login to Azure for Key Vault signing
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Set Azure Key Vault access token
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      shell: pwsh
+      run: |
+        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
+        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
+        Write-Host "::add-mask::$token"
+        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     # END JP PATCH
     - name: Prepare source code
       shell: cmd
@@ -473,6 +509,10 @@ jobs:
     runs-on: ${{ needs.matrix.outputs.defaultRunner }}
     needs: [matrix, buildNVDA]
     timeout-minutes: 35
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -480,6 +520,9 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
+      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, push/workflow_dispatch only)
+      AZURE_KV_SIGNING: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && vars.AZURE_KV_SIGNING || '' }}
+      # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.
       # So we only set the output variables for the default architecture.
@@ -518,12 +561,35 @@ jobs:
       shell: cmd
       run: scons %sconsDocsOutTargets% %sconsArgs% %sconsCores%
     # Run launcher separately as we can't safely generate that in parallel to docs scons targets (#18867)
+    # BEGIN JP PATCH (install AzureSignTool before Azure KV signing)
+    - name: Install AzureSignTool
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      shell: pwsh
+      run: |
+        dotnet tool install --global AzureSignTool --version 7.0.1
+        Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # END JP PATCH
+    # BEGIN JP PATCH (Azure Key Vault signing with OIDC - push/workflow_dispatch only)
+    - name: Login to Azure for Key Vault signing
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Set Azure Key Vault access token
+      if: ${{ env.AZURE_KV_SIGNING == '1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      shell: pwsh
+      run: |
+        $token = (az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv)
+        if (-not $token) { throw "Failed to obtain Azure Key Vault access token" }
+        Write-Host "::add-mask::$token"
+        "AZURE_KV_ACCESS_TOKEN=$token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    # END JP PATCH
     - name: Create launcher and controller client
       shell: cmd
       run: |
-        PowerShell -Command "Set-ExecutionPolicy Bypass"
-        PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
-        PowerShell -Command "Install-Module -Name SignPath -Force"
         scons %sconsLauncherOutTargets% %sconsArgs% %sconsCores%
     - name: Upload launcher
       id: uploadLauncher

--- a/ci/scripts/signAzureKV.ps1
+++ b/ci/scripts/signAzureKV.ps1
@@ -129,25 +129,24 @@ function Find-SignToolExe {
 
 function Get-KeyVaultAccessToken {
     Initialize-SigningToolPath
-    if ($env:AZURE_KV_ACCESS_TOKEN) {
-        return $env:AZURE_KV_ACCESS_TOKEN
+    $token = $env:AZURE_KV_ACCESS_TOKEN
+    if ($token) {
+        return $token
     }
     $az = Get-Command az -ErrorAction SilentlyContinue
     if ($az) {
         $token = az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv 2>$null
         if ($LASTEXITCODE -eq 0 -and $token) {
-            return $token.Trim()
+            $token = $token.Trim()
+            Write-Host "::add-mask::$token"
+            return $token
         }
-    }
-    if ($env:AZURE_CLIENT_SECRET -and $env:AZURE_CLIENT_ID -and $env:AZURE_TENANT_ID) {
-        return $null
     }
     throw @"
 Azure Key Vault signing credentials are not available.
 Set one of:
   - AZURE_KV_ACCESS_TOKEN
   - az login (Azure CLI session)
-  - AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 "@
 }
 

--- a/ci/scripts/signAzureKV.ps1
+++ b/ci/scripts/signAzureKV.ps1
@@ -4,7 +4,6 @@
 # Authentication (first match wins):
 #   1. AZURE_KV_ACCESS_TOKEN  - pre-issued token (GitHub Actions OIDC)
 #   2. az account get-access-token  - local `az login` session
-#   3. AZURE_CLIENT_SECRET + AZURE_CLIENT_ID + AZURE_TENANT_ID
 #
 # Key Vault settings (defaults match shuaruta/code-signing):
 #   AZURE_KEY_VAULT_URI, CERT_NAME (certificate name in Key Vault)
@@ -171,19 +170,11 @@ $signArgs = @(
     "sign",
     "-kvu", $keyVaultUri,
     "-kvc", $certName,
+    "-kva", $accessToken,
     "-tr", $timestampUrl,
     "-fd", "sha256",
     "-v"
 )
-if ($accessToken) {
-    $signArgs += @("-kva", $accessToken)
-} else {
-    $signArgs += @(
-        "-kvi", $env:AZURE_CLIENT_ID,
-        "-kvs", $env:AZURE_CLIENT_SECRET,
-        "-kvt", $env:AZURE_TENANT_ID
-    )
-}
 $signArgs += $FileToSign
 
 & $azureSignTool @signArgs

--- a/sconstruct
+++ b/sconstruct
@@ -271,9 +271,6 @@ elif useAzureKvSigning:
 		"TIMESTAMP_URL",
 		"TIMESERVER",
 		"AZURE_KV_ACCESS_TOKEN",
-		"AZURE_CLIENT_ID",
-		"AZURE_CLIENT_SECRET",
-		"AZURE_TENANT_ID",
 	)
 
 	def _azureKvSignShellCmd(filePath: str) -> str:


### PR DESCRIPTION
This PR mirrors the alphajp Azure Key Vault signing changes for the betajp branch.

Changes:
- Enable Azure Key Vault signing via repository variable AZURE_KV_SIGNING on push/workflow_dispatch only.
- Add id-token: write permissions and Azure OIDC login to uildNVDA and createLauncher jobs.
- Install AzureSignTool 7.0.1 and retrieve a masked Azure KV access token before scons source and launcher builds.
- Remove SignPath PowerShell module install from createLauncher while keeping existing SCons SignPath invocation paths.
- Harden ci/scripts/signAzureKV.ps1: remove AZURE_CLIENT_SECRET fallback and mask dynamically retrieved tokens.

Validation:
- [ ] workflow_dispatch on betajp-azure-kv-signing signs the launcher successfully.
- [ ] PR CI skips signing because AZURE_KV_SIGNING is empty for pull_request events.

Refs #539.