### PR TITLE
add publishBetaRelease job for beta pre-release and S3 beta-meta.json upload

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -92,10 +92,8 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
-      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, workflow_dispatch only)
+      # BEGIN JP PATCH (Azure KV signing + nowdate for betajp release)
       AZURE_KV_SIGNING: ${{ github.event_name == 'workflow_dispatch' && vars.AZURE_KV_SIGNING || '' }}
-      # END JP PATCH
-      # BEGIN JP PATCH (use nowdate computed once in matrix job)
       NOWDATE: ${{ needs.matrix.outputs.nowdate }}
       # END JP PATCH
     outputs:
@@ -559,10 +557,8 @@ jobs:
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
-      # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, workflow_dispatch only)
+      # BEGIN JP PATCH (Azure KV signing + nowdate for betajp release)
       AZURE_KV_SIGNING: ${{ github.event_name == 'workflow_dispatch' && vars.AZURE_KV_SIGNING || '' }}
-      # END JP PATCH
-      # BEGIN JP PATCH (use nowdate computed once in matrix job)
       NOWDATE: ${{ needs.matrix.outputs.nowdate }}
       # END JP PATCH
     outputs:
@@ -833,12 +829,10 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs: [buildNVDA, typeCheck, checkPot, licenseCheck, unitTests, createLauncher, systemTests, createSymbols
-      # BEGIN JP PATCH
+      # BEGIN JP PATCH (jpSmokeTests added; checkPo temporarily disabled)
       , jpSmokeTests
-      # END JP PATCH
-      # BEGIN JP PATCH (checkPo temporarily disabled)
       # , checkPo
-      # END JP PATCH (checkPo temporarily disabled)
+      # END JP PATCH
     ]
     steps:
     - name: Check if all tests pass

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -1052,7 +1052,6 @@ jobs:
           --title "$version" \
           --notes-file "$notes_file" \
           --prerelease
-    # BEGIN JP PATCH (S3 beta-meta.json upload via AWS OIDC, no long-term keys)
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -1071,8 +1070,7 @@ jobs:
           "apiCompatTo": "${{ needs.buildNVDA.outputs.APIBackCompat }}"
         }
         EOF
-        aws s3 cp beta-meta.json s3://nvdajp/beta/beta-meta.json --content-type application/json --acl public-read
-    # END JP PATCH
+        aws s3 cp beta-meta.json s3://nvdajp/beta/beta-meta.json --content-type application/json
     outputs:
       releaseTag: ${{ steps.tag.outputs.TAG }}
       releaseUrl: ${{ steps.tag.outputs.URL }}

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -993,3 +993,91 @@ jobs:
           --discussion-category Releases \
           ${{ ( contains(github.ref_name, 'rc') || contains(github.ref_name, 'beta') ) && '--prerelease' || '' }} \
           $NVDA_EXE_NAME#Installer
+
+  # BEGIN JP PATCH (publish beta pre-release on workflow_dispatch only)
+  publishBetaRelease:
+    name: Publish beta pre-release
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: [matrix, buildNVDA, createLauncher, createSymbols, allTestsPass]
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'betajp'
+    concurrency:
+      group: beta-release
+      cancel-in-progress: true
+    steps:
+    - name: Determine tag
+      shell: bash
+      id: tag
+      run: |
+        tag="betajp-${{ needs.buildNVDA.outputs.version }}"
+        echo "TAG=$tag" >> "$GITHUB_OUTPUT"
+        echo "URL=https://github.com/${{ github.repository }}/releases/tag/$tag" >> "$GITHUB_OUTPUT"
+    - name: Download NVDA launcher
+      uses: actions/download-artifact@v8
+      with:
+        name: NVDA launcher (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
+        path: output
+    - name: Calculate hashes
+      shell: bash
+      id: hashes
+      run: |
+        exe=$(ls output/nvda*.exe | head -n 1)
+        echo "EXE_NAME=$(basename "$exe")" >> "$GITHUB_OUTPUT"
+        echo "SHA1=$(sha1sum "$exe" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+        echo "SHA256=$(sha256sum "$exe" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+    - name: Create pre-release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        tag="${{ steps.tag.outputs.TAG }}"
+        version="${{ needs.buildNVDA.outputs.version }}"
+        exe_name="${{ steps.hashes.outputs.EXE_NAME }}"
+        sha1="${{ steps.hashes.outputs.SHA1 }}"
+        sha256="${{ steps.hashes.outputs.SHA256 }}"
+        notes_file="/tmp/betaReleaseNotes.md"
+        {
+          echo "This is a beta pre-release of the NVDA Japanese Version."
+          echo "It is intended for testing and feedback before the stable release."
+          echo ""
+          echo "* Download: $exe_name"
+          echo "* SHA1: \`$sha1\`"
+          echo "* SHA256: \`$sha256\`"
+        } > "$notes_file"
+        gh release create "$tag" \
+          "output/$exe_name" \
+          --repo ${{ github.repository }} \
+          --title "$version" \
+          --notes-file "$notes_file" \
+          --prerelease
+    # BEGIN JP PATCH (S3 beta-meta.json upload via AWS OIDC, no long-term keys)
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.AWS_BETA_ROLE_ARN }}
+        aws-region: ap-northeast-1
+    - name: Upload beta-meta.json to S3
+      shell: bash
+      run: |
+        cat > beta-meta.json <<EOF
+        {
+          "version": "${{ needs.buildNVDA.outputs.version }}",
+          "launcherUrl": "https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.TAG }}/${{ steps.hashes.outputs.EXE_NAME }}",
+          "sha1": "${{ steps.hashes.outputs.SHA1 }}",
+          "sha256": "${{ steps.hashes.outputs.SHA256 }}",
+          "apiVersion": "${{ needs.buildNVDA.outputs.APIVersion }}",
+          "apiCompatTo": "${{ needs.buildNVDA.outputs.APIBackCompat }}"
+        }
+        EOF
+        aws s3 cp beta-meta.json s3://nvdajp/beta/beta-meta.json --content-type application/json --acl public-read
+    # END JP PATCH
+    outputs:
+      releaseTag: ${{ steps.tag.outputs.TAG }}
+      releaseUrl: ${{ steps.tag.outputs.URL }}
+      exeName: ${{ steps.hashes.outputs.EXE_NAME }}
+      sha1: ${{ steps.hashes.outputs.SHA1 }}
+      sha256: ${{ steps.hashes.outputs.SHA256 }}
+      version: ${{ needs.buildNVDA.outputs.version }}
+  # END JP PATCH

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -61,6 +61,9 @@ jobs:
       supportedRunners: ${{ steps.setMatrix.outputs.supportedRunners }}
       supportedArchitectures: ${{ steps.setMatrix.outputs.supportedArchitectures }}
       supportedPythonVersions: ${{ steps.setMatrix.outputs.supportedPythonVersions }}
+      # BEGIN JP PATCH (compute nowdate once for betajp workflow_dispatch beta release)
+      nowdate: ${{ steps.setMatrix.outputs.nowdate }}
+      # END JP PATCH
     steps:
     - name: Set architecture and python version
       id: setMatrix
@@ -69,6 +72,10 @@ jobs:
         echo "supportedRunners=$(jq -c <<< '${{ env.supportedRunners }}')" >> "$GITHUB_OUTPUT"
         echo "supportedArchitectures=$(jq -c <<< '${{ env.supportedArchitectures }}')" >> "$GITHUB_OUTPUT"
         echo "supportedPythonVersions=$(jq -c <<< '${{ env.supportedPythonVersions }}')" >> "$GITHUB_OUTPUT"
+        # BEGIN JP PATCH (compute JST nowdate once; used by buildNVDA/createLauncher/publishBetaRelease)
+        nowdate=$(python3 -c "from datetime import datetime, timedelta, timezone; jst = datetime.now(timezone.utc).astimezone(timezone(timedelta(hours=9))); print(f'{jst:%y%m%d}{chr(97+jst.hour)}')")
+        echo "nowdate=$nowdate" >> "$GITHUB_OUTPUT"
+        # END JP PATCH
   buildNVDA:
     name: Build NVDA
     needs: matrix
@@ -88,11 +95,15 @@ jobs:
       # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, workflow_dispatch only)
       AZURE_KV_SIGNING: ${{ github.event_name == 'workflow_dispatch' && vars.AZURE_KV_SIGNING || '' }}
       # END JP PATCH
+      # BEGIN JP PATCH (use nowdate computed once in matrix job)
+      NOWDATE: ${{ needs.matrix.outputs.nowdate }}
+      # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.
       # This is not a problem for these variables as they should be the same across jobs.
       version: ${{ steps.releaseInfo.outputs.VERSION }}
       versionType: ${{ steps.releaseInfo.outputs.VERSION_TYPE }}
+      nowdate: ${{ steps.releaseInfo.outputs.NOWDATE }}
       APIVersion: ${{ steps.releaseInfo.outputs.NVDA_API_VERSION }}
       APIBackCompat: ${{ steps.releaseInfo.outputs.NVDA_API_COMPAT_TO }}
     steps:
@@ -253,10 +264,29 @@ jobs:
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}${{ env.SCONS_CACHE_SUFFIX }}
+    # BEGIN JP PATCH (build JP addons on betajp workflow_dispatch so they can be attached to GitHub Release)
+    - name: Build JP addons
+      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      shell: pwsh
+      env:
+        VERSION: ${{ env.nowdate }}
+      run: |
+        uv run --no-active python jptools/pack_jtalk_addon.py --nowdate "$env:VERSION"
+        uv run --no-active python jptools/pack_kgs_addon.py --version "$env:VERSION"
+    - name: Upload JP addon artifacts
+      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: JP addons (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
+        path: |
+          jptools/nvdajp-jtalk-*.nvda-addon
+          jptools/kgsbraille-*.nvda-addon
+    # END JP PATCH
     - name: Store release metadata information
       id: releaseInfo
       run: |
         Write-Output VERSION=$env:version >> $env:GITHUB_OUTPUT
+        Write-Output NOWDATE=$env:nowdate >> $env:GITHUB_OUTPUT
         Write-Output VERSION_TYPE=$env:versionType >> $env:GITHUB_OUTPUT
         Write-Output NVDA_API_VERSION=$(python -c "import sys; sys.path.append('source'); from addonAPIVersion import CURRENT; print('{}.{}.{}'.format(*CURRENT))") >> $env:GITHUB_OUTPUT
         Write-Output NVDA_API_COMPAT_TO=$(python -c "import sys; sys.path.append('source'); from addonAPIVersion import BACK_COMPAT_TO; print('{}.{}.{}'.format(*BACK_COMPAT_TO))") >> $env:GITHUB_OUTPUT
@@ -532,6 +562,9 @@ jobs:
       # BEGIN JP PATCH (enable Azure Key Vault signing via repository variable, workflow_dispatch only)
       AZURE_KV_SIGNING: ${{ github.event_name == 'workflow_dispatch' && vars.AZURE_KV_SIGNING || '' }}
       # END JP PATCH
+      # BEGIN JP PATCH (use nowdate computed once in matrix job)
+      NOWDATE: ${{ needs.matrix.outputs.nowdate }}
+      # END JP PATCH
     outputs:
       # Note: each output variable is overwritten by the last job in the matrix.
       # So we only set the output variables for the default architecture.
@@ -605,10 +638,30 @@ jobs:
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
-    - name: Create launcher and controller client
-      shell: cmd
+    # BEGIN JP PATCH (install AzureSignTool before Azure KV signing)
+    - name: Install AzureSignTool
+      if: ${{ env.AZURE_KV_SIGNING == '1' }}
+      shell: pwsh
       run: |
-        scons %sconsLauncherOutTargets% %sconsArgs% %sconsCores%
+        dotnet tool install --global AzureSignTool --version 7.0.1
+        Join-Path $env:USERPROFILE ".dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # END JP PATCH
+    - name: Build NVDAController client
+      shell: cmd
+      run: scons client %sconsArgs% %sconsCores%
+    - name: Create NVDA launcher
+      shell: cmd
+      run: scons %sconsLauncherOutTargets% %sconsArgs%
+    - name: Rename controller client archive for JP release
+      shell: pwsh
+      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      run: |
+        $cc = Get-ChildItem -Path output -Filter "nvda_*controllerClient.zip" | Select-Object -First 1
+        if ($cc) {
+          $newName = "output/nvda_$env:version`_controllerClientJp.zip"
+          Move-Item -LiteralPath $cc.FullName -Destination $newName -Force
+          Write-Host "Renamed controller client to $newName"
+        }
     - name: Upload launcher
       id: uploadLauncher
       uses: actions/upload-artifact@v7
@@ -1014,11 +1067,16 @@ jobs:
         tag="betajp-${{ needs.buildNVDA.outputs.version }}"
         echo "TAG=$tag" >> "$GITHUB_OUTPUT"
         echo "URL=https://github.com/${{ github.repository }}/releases/tag/$tag" >> "$GITHUB_OUTPUT"
-    - name: Download NVDA launcher
+    - name: Download NVDA launcher and JP addons
       uses: actions/download-artifact@v8
       with:
         name: NVDA launcher (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
         path: output
+    - name: Download JP addons
+      uses: actions/download-artifact@v8
+      with:
+        name: JP addons (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
+        path: jptools
     - name: Calculate hashes
       shell: bash
       id: hashes
@@ -1048,6 +1106,9 @@ jobs:
         } > "$notes_file"
         gh release create "$tag" \
           "output/$exe_name" \
+          jptools/nvdajp-jtalk-*.nvda-addon \
+          jptools/kgsbraille-*.nvda-addon \
+          output/nvda_*_controllerClientJp.zip \
           --repo ${{ github.repository }} \
           --title "$version" \
           --notes-file "$notes_file" \

--- a/ci/scripts/setBuildVersionVars.ps1
+++ b/ci/scripts/setBuildVersionVars.ps1
@@ -21,6 +21,11 @@ if ($env:GITHUB_REF_TYPE -eq "tag" -and $env:GITHUB_REF_NAME.StartsWith("release
 		$version = "alpha-$BUILD_NUMBER,$commitVersion"
 	} else {
 		$version = "$env:GITHUB_REF_NAME-$BUILD_NUMBER,$commitVersion"
+		# BEGIN JP PATCH (betajp: use nowdate-based version like 2026.2jp-beta-260720a)
+		if ($env:GITHUB_REF_NAME -eq "betajp" -and $env:NOWDATE) {
+			$version = "2026.2jp-beta-$env:NOWDATE"
+		}
+		# END JP PATCH
 		if ($env:GITHUB_REF_NAME.StartsWith("try-release-")) {
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 		}


### PR DESCRIPTION
## 概要

betajp に publishBetaRelease ジョブを追加します。alphajp の publishAlphaRelease と同様の構成です。

## 変更内容

- publishBetaRelease ジョブを追加（workflow_dispatch かつ etajp ブランチ限定）
- GitHub Release (pre-release) を作成
- eta-meta.json を S3 にアップロード（AWS OIDC）
- タグ形式: etajp-<version>

## 必要な並行作業

- [ ] ars.AWS_BETA_ROLE_ARN の設定（GitHub Variables）
- [ ] S3 バケット s3://nvdajp/beta/ の書き込み権限設定
- [ ] Azure federated credential は etajp ブランチ用が既存

## 注意

- インストーラ本体は GitHub Releases の asset としてホスティング（S3 にはアップロードしない）
- www.nvda.jp 側の beta-meta.json 対応は PR #6 でマージ済み
- この PR は WIP です。上記の並行作業が完了したらレビュー可能