### PR TITLE
fix(winword): check double strikethrough before single strikethrough

### DIFF
--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -663,10 +663,10 @@ void generateXMLAttribsForFormatting(IDispatch* pDispatchRange, int startOffset,
 				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_UNDERLINE,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"underline=\"1\" ";
 				}
-				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_STRIKETHROUGH,VT_I4,&iVal)==S_OK&&iVal) {
-					formatAttribsStream<<L"strikethrough=\"1\" ";
-				} else if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_DOUBLESTRIKETHROUGH,VT_I4,&iVal)==S_OK&&iVal) {
+				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_DOUBLESTRIKETHROUGH,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"strikethrough=\"double\" ";
+				} else if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_STRIKETHROUGH,VT_I4,&iVal)==S_OK&&iVal) {
+					formatAttribsStream<<L"strikethrough=\"1\" ";
 				}
 				if(_com_dispatch_raw_propget(pDispatchFont,wdDISPID_FONT_HIDDEN,VT_I4,&iVal)==S_OK&&iVal) {
 					formatAttribsStream<<L"hidden=\"1\" ";


### PR DESCRIPTION
### 概要

Word で二重取り消し線を設定した場合、Strikethrough プロパティも True を返すため、二重取り消し線の判定に到達せず、常に単一取り消し線として報告されていました。

### 変更内容


vdaHelper/remote/winword.cpp の wdDISPID_FONT_STRIKETHROUGH と wdDISPID_FONT_DOUBLESTRIKETHROUGH のチェック順序を入れ替え、二重取り消し線を先にチェックするように修正しました。

### 関連 issue

- Fixes #575

### 検証

- 型チェック: 未実施（C++ コードのため）
- 実機検証: 未実施（Word で二重取り消し線を設定し NVDA+F で確認）