### PR TITLE
UIA経路で二重取り消し線を区別して報告する (issue #710)

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -203,9 +203,17 @@ class UIATextInfo(textInfos.TextInfo):
 		val = fetch(UIAHandler.UIA_UnderlineStyleAttributeId)
 		if val != UIAHandler.handler.reservedNotSupportedValue:
 			formatField["underline"] = bool(val)
+		# BEGIN JP PATCH (issue #710): UIA returns a TextDecorationLineStyleEnum value for
+		# UIA_StrikethroughStyleAttributeId. Report double strikethrough distinctly from single.
 		val = fetch(UIAHandler.UIA_StrikethroughStyleAttributeId)
 		if val != UIAHandler.handler.reservedNotSupportedValue:
-			formatField["strikethrough"] = bool(val)
+			if val == 3:  # TextDecorationLineStyle_Double
+				formatField["strikethrough"] = "double"
+			elif val == 1:  # TextDecorationLineStyle_Single
+				formatField["strikethrough"] = True
+			elif val:
+				formatField["strikethrough"] = bool(val)
+			# END JP PATCH
 
 	def _getFormatFieldSuperscriptsAndSubscripts(
 		self,


### PR DESCRIPTION
## 概要

Word 2016 build 15000 以上 + Windows 11 では NVDA は UIA 経路を使用する。
UIA_StrikethroughStyleAttributeId は TextDecorationLineStyleEnum を返すため、これまでは single/double の区別ができず、どちらも 取り消し線 と報告されていた。

## 変更内容

- source/NVDAObjects/UIA/__init__.py の _getFormatFieldFontAttributes で、値に応じて区別:
  - 3 (TextDecorationLineStyle_Double) -> strikethrough=double
  - 1 (TextDecorationLineStyle_Single) -> strikethrough=True
  - その他の truthy 値 -> 従来通り bool(val)

これにより、音声・点字で 2重取り消し線 と正しく報告される。

## 検証

- ローカルでの scons は DLL ロックにより中断中
- ユーザーは PC 再起動後に手動で runnvda で検証予定
- CI 経由での検証を依頼

## 影響範囲

- UIA 経路を使用する Word 2016/2019/2021/Microsoft 365
- COM 経路の修正（nvdaHelper/remote/winword.cpp）は既に入っているため、両経路で二重取り消し線が区別されるようになる。