### PR TITLE
fix: fall back to base language for missing full locale symbols (issue #494)

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -563,7 +563,9 @@ class SpeechSymbolProcessor:
 
 		# We need to merge symbol data from several sources.
 		sources = self.sources = []
-		fetched = self.localeSymbols.fetchLocaleData(locale, fallback=False)
+		# BEGIN JP PATCH (issue #494: fall back to base language when full locale is missing)
+		fetched = self.localeSymbols.fetchLocaleData(locale, fallback=True)
+		# END JP PATCH
 		# A slice that reverses a list and ignores the last item (which is the user dictionary)
 		builtinSlice = slice(-2, None, -1)
 		self.builtinSources = list(fetched[builtinSlice])
@@ -936,7 +938,9 @@ class SymbolDictionaryDefinition:
 		:param locale: The locale to get symbols for.
 		:raises FileNotFoundError: When this is not a user dictionary and the locale wasn't found.
 		"""
-		return self.symbols.fetchLocaleData(locale, fallback=False)
+		# BEGIN JP PATCH (issue #494: fall back to base language when full locale is missing)
+		return self.symbols.fetchLocaleData(locale, fallback=True)
+		# END JP PATCH
 
 	def _initSymbols(self, locale: str) -> SpeechSymbols:
 		raiseOnError = self.source != _SymbolDefinitionSource.USER

--- a/tests/unit/test_characterProcessing.py
+++ b/tests/unit/test_characterProcessing.py
@@ -11,6 +11,7 @@ from characterProcessing import SpeechSymbolProcessor
 from characterProcessing import SymbolLevel
 from characterProcessing import processSpeechSymbols as process
 from characterProcessing import processSpeechSymbol
+from characterProcessing import LocaleDataMap
 
 
 class TestComplex(unittest.TestCase):
@@ -183,3 +184,39 @@ class TestUsingCLDR(unittest.TestCase):
 				CHAR_IN_SYMB_FILE_DESC,
 				msg=f'Test failure for locale={locale} with "{CHAR_IN_SYMB_FILE_DESC}"',
 			)
+
+
+class TestLocaleDataMapFallback(unittest.TestCase):
+	"""Test that LocaleDataMap falls back to the base language when the full locale is missing.
+
+	Regression test for issue #494: requesting symbols for a locale such as 'ja_JP'
+	(which has no dedicated data) should fall back to 'ja' instead of raising LookupError.
+	"""
+
+	def _makeMap(self):
+		"""Create a LocaleDataMap whose factory only supports base languages (no country variants)."""
+		available = {"ja", "en", "fr"}
+
+		def factory(locale):
+			if locale in available:
+				return f"data:{locale}"
+			raise LookupError(locale)
+
+		return LocaleDataMap(factory)
+
+	def test_fallback_to_base_language(self):
+		"""fetchLocaleData('ja_JP') should return the 'ja' data when fallback=True."""
+		dataMap = self._makeMap()
+		self.assertEqual(dataMap.fetchLocaleData("ja_JP", fallback=True), "data:ja")
+
+	def test_no_fallback_raises(self):
+		"""fetchLocaleData('ja_JP') should raise LookupError when fallback=False."""
+		dataMap = self._makeMap()
+		with self.assertRaises(LookupError):
+			dataMap.fetchLocaleData("ja_JP", fallback=False)
+
+	def test_exact_locale_preferred(self):
+		"""An exact locale match should be used even when fallback is enabled."""
+		dataMap = self._makeMap()
+		self.assertEqual(dataMap.fetchLocaleData("fr", fallback=True), "data:fr")
+


### PR DESCRIPTION
Fixes #494

## Summary

When a full locale such as `ja_JP` has no dedicated symbol data, NVDA raised `FileNotFoundError: No 'builtin' data for locale 'ja_JP'`. This change makes the symbol dictionaries fall back to the base language (`ja`) instead, matching the behavior of character descriptions which already fall back.

## Changes

- `source/characterProcessing.py`: change `fetchLocaleData(locale, fallback=False)` to `fallback=True` in two places (symbol processor init and `getSymbols`).
- `tests/unit/test_characterProcessing.py`: add unit tests for `LocaleDataMap` fallback behavior.

## Testing

- `uv run --no-active python -m unittest tests.unit.test_characterProcessing -v` passes (14 tests).
