### PR TITLE
fix: fall back to individual UIA attribute fetches on GetAttributeValues COMError (issue #717)

### DIFF
--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -266,10 +266,14 @@ class BulkUIATextRangeAttributeValueFetcher(UIATextRangeAttributeValueFetcher):
 		try:
 			values = textRange.GetAttributeValues(IDsArray, len(IDsArray))
 		except COMError:
-			# #717: Some UIA providers (e.g. Chrome) can raise a COMError
+			# Some UIA providers (e.g. Chrome) can raise a COMError
 			# (such as RPC_E_SERVERFAULT) when fetching multiple attribute values
-			# in a single cross-process call. Fall back to fetching each attribute
-			# individually, which handles COMError per attribute (see #7124).
+			# in a single cross-process call via GetAttributeValues.
+			# Fall back to fetching each attribute individually via getAttributeValue,
+			# which already handles COMError per attribute (see nvaccess#7124).
+			# This is not silently swallowing the error — the bulk fetch is an
+			# optimization; falling back to the individual path preserves text and
+			# braille output, at the cost of one cross-process call per attribute.
 			log.debugWarning("GetAttributeValues failed, falling back to individual fetches", exc_info=True)
 			return
 		self.IDsToValues = {IDs[x]: values[x] for x in range(len(IDs))}

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -260,13 +260,24 @@ class UIATextRangeAttributeValueFetcher(object):
 class BulkUIATextRangeAttributeValueFetcher(UIATextRangeAttributeValueFetcher):
 	def __init__(self, textRange, IDs):
 		IDs = list(IDs)
-		self.IDsToValues = {}
+		self.IDsToValues = None
 		super(BulkUIATextRangeAttributeValueFetcher, self).__init__(textRange)
 		IDsArray = (ctypes.c_long * len(IDs))(*IDs)
-		values = textRange.GetAttributeValues(IDsArray, len(IDsArray))
+		try:
+			values = textRange.GetAttributeValues(IDsArray, len(IDsArray))
+		except COMError:
+			# #717: Some UIA providers (e.g. Chrome) can raise a COMError
+			# (such as RPC_E_SERVERFAULT) when fetching multiple attribute values
+			# in a single cross-process call. Fall back to fetching each attribute
+			# individually, which handles COMError per attribute (see #7124).
+			log.debugWarning("GetAttributeValues failed, falling back to individual fetches", exc_info=True)
+			return
 		self.IDsToValues = {IDs[x]: values[x] for x in range(len(IDs))}
 
 	def getValue(self, ID, ignoreMixedValues=False):
+		if self.IDsToValues is None:
+			# Fall back to the individual attribute value fetcher.
+			return super().getValue(ID, ignoreMixedValues=ignoreMixedValues)
 		val = self.IDsToValues[ID]
 		if not ignoreMixedValues and val == UIAHandler.handler.ReservedMixedAttributeValue:
 			raise UIAMixedAttributeError

--- a/tests/unit/test_UIAHandler.py
+++ b/tests/unit/test_UIAHandler.py
@@ -5,9 +5,13 @@
 # https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from comtypes import COMError
 
 import textInfos
 from UIAHandler import NVDAUnitsToUIAUnits, getUIAUnitFromNVDAUnit
+from UIAHandler.utils import BulkUIATextRangeAttributeValueFetcher
 
 
 class Test_getUIAUnitFromNVDAUnit(TestCase):
@@ -20,3 +24,44 @@ class Test_getUIAUnitFromNVDAUnit(TestCase):
 	def test_unmappedUnitRaisesNotImplementedError(self):
 		with self.assertRaises(NotImplementedError):
 			getUIAUnitFromNVDAUnit(textInfos.UNIT_SENTENCE)
+
+
+class TestBulkUIATextRangeAttributeValueFetcher(TestCase):
+	"""Tests for the bulk UIA text range attribute value fetcher."""
+
+	def _makeHandler(self):
+		handler = Mock()
+		handler.ReservedMixedAttributeValue = "mixed"
+		handler.reservedNotSupportedValue = "not-supported"
+		return handler
+
+	def test_getAttributeValuesCOMErrorFallsBackToIndividualFetches(self):
+		"""A COMError from GetAttributeValues should fall back to individual fetches."""
+		textRange = Mock()
+		textRange.GetAttributeValues.side_effect = COMError(-2147417851, "server fault", None)
+		# Individual fetches succeed.
+		textRange.getAttributeValue.side_effect = lambda ID: {1: "value1", 2: "value2"}[ID]
+		with patch("UIAHandler.utils.UIAHandler.handler", self._makeHandler()):
+			fetcher = BulkUIATextRangeAttributeValueFetcher(textRange, [1, 2])
+			self.assertEqual(fetcher.getValue(1), "value1")
+			self.assertEqual(fetcher.getValue(2), "value2")
+		textRange.GetAttributeValues.assert_called_once()
+
+	def test_getAttributeValuesSucceeds(self):
+		"""A successful GetAttributeValues should be used directly."""
+		textRange = Mock()
+		textRange.GetAttributeValues.return_value = ["value1", "value2"]
+		with patch("UIAHandler.utils.UIAHandler.handler", self._makeHandler()):
+			fetcher = BulkUIATextRangeAttributeValueFetcher(textRange, [1, 2])
+			self.assertEqual(fetcher.getValue(1), "value1")
+			self.assertEqual(fetcher.getValue(2), "value2")
+		textRange.getAttributeValue.assert_not_called()
+
+	def test_getAttributeValuesCOMErrorIndividualFetchAlsoFails(self):
+		"""If both bulk and individual fetches fail, reservedNotSupportedValue is returned."""
+		textRange = Mock()
+		textRange.GetAttributeValues.side_effect = COMError(-2147417851, "server fault", None)
+		textRange.getAttributeValue.side_effect = COMError(-2147417851, "server fault", None)
+		with patch("UIAHandler.utils.UIAHandler.handler", self._makeHandler()):
+			fetcher = BulkUIATextRangeAttributeValueFetcher(textRange, [1, 2])
+			self.assertEqual(fetcher.getValue(1), "not-supported")


### PR DESCRIPTION
## 概要

Fixes #717

Chrome のアドレスバーにフォーカスを移動すると、`gainFocus` イベント処理中に `RPC_E_SERVERFAULT` (0x80010105) が発生し、点字ディスプレイ上にアドレスバーの内容が表示されない問題を修正します。

## 原因

例外は `UIAHandler/utils.py` の `BulkUIATextRangeAttributeValueFetcher.__init__` 内の `textRange.GetAttributeValues(...)` 一括呼び出しで発生しています。この一括フェッチ経路は `COMError` を捕捉しておらず、例外が `event_gainFocus` 全体まで伝播して点字表示が止まります。

対照的に、同じファイル内の個別フェッチ `UIATextRangeAttributeValueFetcher.getValue` は `COMError` を捕捉して `reservedNotSupportedValue` を返します（#7124 対応）。つまり一括フェッチ経路だけが例外処理を欠いています。

## 変更内容

`BulkUIATextRangeAttributeValueFetcher` で `GetAttributeValues` が `COMError` を投げた場合、個別フェッチの `UIATextRangeAttributeValueFetcher` にフォールバックするようにしました。これにより一括フェッチが失敗しても個別フェッチで各属性を取得でき、点字・音声の表示が継続されます。

- `source/UIAHandler/utils.py`: `BulkUIATextRangeAttributeValueFetcher` に COMError フォールバックを追加
- `tests/unit/test_UIAHandler.py`: フォールバック動作の単体テストを追加

## テスト

- 単体テスト: `tests/unit/test_UIAHandler.py` の全テストがパス（68 tests OK）
- 型チェック: `typeCheck.ps1` で 0 errors / 0 warnings
- lint: `ruff check` で All checks passed

## 上流への適性

言語・地域に依存しない汎用バグ修正であり、単体テスト付き・JP 固有設定非依存のため、本家 `nvaccess/nvda` への提案候補です（`projectDocs/jp/upstream-contribution-roadmap.md` に追記予定）。
