### PR TITLE
feat: enable releasejp signed release builds via GitHub Actions workflow_dispatch

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -276,7 +276,7 @@ jobs:
       if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       shell: pwsh
       env:
-        VERSION: ${{ github.ref_name == 'releasejp' && env.version || nowdate }}
+        VERSION: ${{ github.ref_name == 'releasejp' && env.version || env.nowdate }}
       run: |
         uv run --no-active python jptools/pack_jtalk_addon.py --nowdate "$env:VERSION"
         uv run --no-active python jptools/pack_kgs_addon.py --version "$env:VERSION"

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -20,6 +20,13 @@ on:
       # Original upstream branches (master, beta, rc) removed for nvdajp
 
   workflow_dispatch:
+    inputs:
+      # BEGIN JP PATCH (releasejp signed release builds)
+      releaseTag:
+        description: 'Release tag for releasejp (e.g. release-2026.2jp-rc1 or release-2026.2jp)'
+        required: false
+        type: string
+      # END JP PATCH
 
 concurrency:
   # BEGIN JP PATCH (separate concurrency groups by event name so workflow_dispatch is not cancelled by push)
@@ -264,17 +271,17 @@ jobs:
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}${{ env.SCONS_CACHE_SUFFIX }}
-    # BEGIN JP PATCH (build JP addons on betajp workflow_dispatch so they can be attached to GitHub Release)
+    # BEGIN JP PATCH (build JP addons on betajp/releasejp workflow_dispatch so they can be attached to GitHub Release)
     - name: Build JP addons
-      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       shell: pwsh
       env:
-        VERSION: ${{ env.nowdate }}
+        VERSION: ${{ github.ref_name == 'releasejp' && env.version || nowdate }}
       run: |
         uv run --no-active python jptools/pack_jtalk_addon.py --nowdate "$env:VERSION"
         uv run --no-active python jptools/pack_kgs_addon.py --version "$env:VERSION"
     - name: Upload JP addon artifacts
-      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       uses: actions/upload-artifact@v7
       with:
         name: JP addons (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
@@ -652,7 +659,7 @@ jobs:
       run: scons %sconsLauncherOutTargets% %sconsArgs%
     - name: Rename controller client archive for JP release
       shell: pwsh
-      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       run: |
         $cc = Get-ChildItem -Path output -Filter "nvda_*controllerClient.zip" | Select-Object -First 1
         if ($cc) {
@@ -1152,6 +1159,106 @@ jobs:
         }
         EOF
         aws s3 cp beta-meta.json s3://nvdajp/beta/beta-meta.json --content-type application/json --acl public-read
+    outputs:
+      releaseTag: ${{ steps.tag.outputs.TAG }}
+      releaseUrl: ${{ steps.tag.outputs.URL }}
+      exeName: ${{ steps.hashes.outputs.EXE_NAME }}
+      sha1: ${{ steps.hashes.outputs.SHA1 }}
+      sha256: ${{ steps.hashes.outputs.SHA256 }}
+      version: ${{ needs.buildNVDA.outputs.version }}
+  # END JP PATCH
+
+  # BEGIN JP PATCH (publish releasejp release on workflow_dispatch only)
+  publishRelease:
+    name: Publish release
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: [matrix, buildNVDA, createLauncher, createSymbols, allTestsPass]
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'releasejp'
+    concurrency:
+      group: releasejp-release
+      cancel-in-progress: true
+    steps:
+    - name: Determine tag
+      shell: bash
+      id: tag
+      run: |
+        tag="${{ inputs.releaseTag }}"
+        if [ -z "$tag" ]; then
+          echo "Error: releaseTag input is required for releasejp workflow_dispatch" >&2
+          exit 1
+        fi
+        case "$tag" in
+          release-*jp*)
+            ;;
+          *)
+            echo "Error: releaseTag must start with 'release-' and contain 'jp'" >&2
+            exit 1
+            ;;
+        esac
+        if echo "$tag" | grep -qE 'rc|beta'; then
+          prerelease_flag="--prerelease"
+        else
+          prerelease_flag=""
+        fi
+        echo "TAG=$tag" >> "$GITHUB_OUTPUT"
+        echo "URL=https://github.com/${{ github.repository }}/releases/tag/$tag" >> "$GITHUB_OUTPUT"
+        echo "PRERELEASE_FLAG=$prerelease_flag" >> "$GITHUB_OUTPUT"
+    - name: Download NVDA launcher and JP addons
+      uses: actions/download-artifact@v8
+      with:
+        name: NVDA launcher (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
+        path: output
+    - name: Download JP addons
+      uses: actions/download-artifact@v8
+      with:
+        name: JP addons (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
+        path: jptools
+    - name: Calculate hashes
+      shell: bash
+      id: hashes
+      run: |
+        exe=$(ls output/nvda*.exe | head -n 1)
+        echo "EXE_NAME=$(basename "$exe")" >> "$GITHUB_OUTPUT"
+        echo "SHA1=$(sha1sum "$exe" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+        echo "SHA256=$(sha256sum "$exe" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+    - name: Create release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PRERELEASE_FLAG: ${{ steps.tag.outputs.PRERELEASE_FLAG }}
+      run: |
+        tag="${{ steps.tag.outputs.TAG }}"
+        version="${{ needs.buildNVDA.outputs.version }}"
+        exe_name="${{ steps.hashes.outputs.EXE_NAME }}"
+        sha1="${{ steps.hashes.outputs.SHA1 }}"
+        sha256="${{ steps.hashes.outputs.SHA256 }}"
+        notes_file="/tmp/releaseNotes.md"
+        if [ -n "$PRERELEASE_FLAG" ]; then
+          title_text="Pre-release "
+          body_text="This is a pre-release of the NVDA Japanese Version. It is intended for testing and feedback before the stable release."
+        else
+          title_text=""
+          body_text="This is the stable release of the NVDA Japanese Version."
+        fi
+        {
+          echo "$body_text"
+          echo ""
+          echo "* Download: $exe_name"
+          echo "* SHA1: \`$sha1\`"
+          echo "* SHA256: \`$sha256\`"
+        } > "$notes_file"
+        gh release create "$tag" \
+          "output/$exe_name" \
+          jptools/nvdajp-jtalk-*.nvda-addon \
+          jptools/kgsbraille-*.nvda-addon \
+          output/nvda_*_controllerClientJp.zip \
+          --repo ${{ github.repository }} \
+          --title "${title_text}$version" \
+          --notes-file "$notes_file" \
+          $PRERELEASE_FLAG
     outputs:
       releaseTag: ${{ steps.tag.outputs.TAG }}
       releaseUrl: ${{ steps.tag.outputs.URL }}

--- a/ci/scripts/setBuildVersionVars.ps1
+++ b/ci/scripts/setBuildVersionVars.ps1
@@ -29,6 +29,14 @@ if ($env:GITHUB_REF_TYPE -eq "tag" -and $env:GITHUB_REF_NAME.StartsWith("release
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 		}
 		# END JP PATCH
+		# BEGIN JP PATCH (releasejp: use 2026.2jp for workflow_dispatch signed releases)
+		if ($env:GITHUB_REF_NAME -eq "releasejp" -and $env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
+			$version = "2026.2jp"
+			$release = 1
+			$versionType = "nvdajp"
+			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+		}
+		# END JP PATCH
 		if ($env:GITHUB_REF_NAME.StartsWith("try-release-")) {
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 		}

--- a/ci/scripts/setBuildVersionVars.ps1
+++ b/ci/scripts/setBuildVersionVars.ps1
@@ -29,9 +29,9 @@ if ($env:GITHUB_REF_TYPE -eq "tag" -and $env:GITHUB_REF_NAME.StartsWith("release
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 		}
 		# END JP PATCH
-		# BEGIN JP PATCH (releasejp: use 2026.2jp for workflow_dispatch signed releases)
+		# BEGIN JP PATCH (releasejp: derive version from buildVersion.py for workflow_dispatch signed releases)
 		if ($env:GITHUB_REF_NAME -eq "releasejp" -and $env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
-			$version = "2026.2jp"
+			$version = python -c "import sys; sys.path.append('source'); import buildVersion; print(f'{buildVersion.version_year}.{buildVersion.version_major}jp')"
 			$release = 1
 			$versionType = "nvdajp"
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/projectDocs/jp/code-signing-dependencies.md
+++ b/projectDocs/jp/code-signing-dependencies.md
@@ -80,6 +80,69 @@ jtalkPrep -> jtalkSync -> source -> user_docs -> dist -> jpCertExtras -> launche
 - `scons.bat source user_docs dist` を先に完了させる。
 - 必要に応じて `scons.bat jtalkSync dist` を再実行する。
 
+## GitHub Actions によるクラウド署名リリース（2026.2jp 移行）
+
+2026.2jp から `releasejp` ブランチでも `alphajp` / `betajp` と同様に、GitHub Actions の `workflow_dispatch` で Azure Key Vault 署名付きリリースビルドを行えるようになった。
+
+### 発火条件と署名の有無
+
+| ブランチ | push / pull_request | workflow_dispatch |
+|---|---|---|
+| alphajp | 署名なし | 署名あり（Azure KV） |
+| betajp | 署名なし | 署名あり（Azure KV） |
+| releasejp | 署名なし | 署名あり（Azure KV）※本 PR で追加 |
+
+- `push` / `pull_request` は常に署名なしビルドである。
+- 署名が必要なリリース / プレリリースは必ず `workflow_dispatch` で発火する。
+
+### リリースワークフローの使い分け
+
+#### alphajp（自動タグ生成）
+
+```text
+workflow_dispatch on alphajp
+  → publishAlphaRelease
+  → タグ: alphajp-{YYMMDD}{hour}
+  → 常にプレリリース
+```
+
+#### betajp（自動タグ生成）
+
+```text
+workflow_dispatch on betajp
+  → publishBetaRelease
+  → タグ: betajp-{YYYY.Mjp-beta-YYMMDD}{hour}
+  → 常にプレリリース
+  → S3 へ beta-meta.json をアップロード
+```
+
+#### releasejp（人がタグを指定）
+
+```text
+workflow_dispatch on releasejp + releaseTag 入力
+  → publishRelease
+  → タグ: 入力で指定（例: release-2026.2jp-rc1 / release-2026.2jp）
+  → rc / beta を含むタグ名 → プレリリース
+  → 含まないタグ名 → 正式リリース
+```
+
+- `releaseTag` 入力は必須。`release-` で始まり `jp` を含む形式を要求する。
+- 成果物は `nvda_2026.2jp.exe`、`nvdajp-jtalk-*.nvda-addon`、`kgsbraille-*.nvda-addon`、`nvda_*_controllerClientJp.zip`。
+
+### リリース手順例（2026.2jp RC1）
+
+1. `releasejp` ブランチを最新にする
+2. GitHub Actions → CI/CD Japanese Version → `Run workflow`
+3. ブランチ: `releasejp`、入力 `releaseTag: release-2026.2jp-rc1` で発火
+4. 全テストが通過すれば `nvda_2026.2jp.exe` が署名付きで作成され、GitHub Releases にプレリリースとして公開される
+
+RC で不備が見つかった場合は修正コミットを `releasejp` ブランチに追加し、次の `releaseTag`（例: `release-2026.2jp-rc2`）で再度発火する。OK ならば最後の RC と同じコミットに `release-2026.2jp` タグを追加して `workflow_dispatch` から正式リリースを作成する。
+
+### 更新通知
+
+- RC / プレリリースでは `version=2026.2jp`、`updateVersionType=nvdajp` として署名ビルドが作成される。
+- 実行後、NVDA の更新チェックは `2026.2jp` を自身のバージョンとして通知する。
+
 ## 関連
 
 - `jptools/scons_jp.py`


### PR DESCRIPTION
This PR enables signed release candidate and stable release builds for the Japanese version from GitHub Actions, matching the existing alphajp/betajp workflow_dispatch pattern.

### Changes

- .github/workflows/testAndPublish.yml
  - Add workflow_dispatch input releaseTag (e.g. release-2026.2jp-rc1 or release-2026.2jp)
  - Build JP addons and rename controllerClientJp.zip for releasejp as well as betajp
  - Add publishRelease job: creates GitHub Releases (prerelease if tag contains rc/beta, stable otherwise)
- ci/scripts/setBuildVersionVars.ps1
  - releasejp workflow_dispatch uses version=2026.2jp and updateVersionType=nvdajp
- projectDocs/jp/code-signing-dependencies.md
  - Document the new cloud signing release flow for releasejp

### Notes

- Branch push / pull_request creates unsigned build; workflow_dispatch creates Azure KV signed build. Tag push does NOT trigger CI (on.push is branches-only).
- RC / beta tags are published as prereleases
- stable tags are published as stable releases
- No S3 upload for releasejp; only GitHub Releases