### PR TITLE
Pin jtalk-dic-version to v1.1.9: fix English reading regressions and loanword readings

### DIFF
--- a/miscDepsJp/jptools/jtalk-dic-version.txt
+++ b/miscDepsJp/jptools/jtalk-dic-version.txt
@@ -3,10 +3,10 @@
 # nishimotz/libkuraji-jtalk-dic release.
 # See projectDocs/jp/vendor-submodules.md ("辞書のビルド時取得（方針転換）").
 repo=nishimotz/libkuraji-jtalk-dic
-tag=v1.1.8
-asset=jtalk-dic-v1.1.8.zip
-sha256=b92ddf3b7e4bc95c3a32e7fadb5abf65f8c216f7a8566e53605ed68378c535be
+tag=v1.1.9
+asset=jtalk-dic-v1.1.9.zip
+sha256=442c143a0092f47c23c6907cee9b2e4a5278621d872c600129550bde38099906
 # mecab-dict-index.exe: used by build_userdic.py to compile jtusr.dic
 # (the user dictionary). Unsigned executable; verified via checksum before use.
-tool_asset=mecab-dict-index-v1.1.8.exe
-tool_sha256=ceb343808b25491da4cd17660bf988aeb2cc032e2e7b9c7e96905166b522776f
+tool_asset=mecab-dict-index-v1.1.9.exe
+tool_sha256=27daa29f4089b03f8f8e42662c149d46b885bd542f136d15a0b24aecc14609dc


### PR DESCRIPTION
## Summary

Update JTalk extended dictionary pin to `v1.1.9` from `nishimotz/libkuraji-jtalk-dic`.

This update resolves the English reading quality regressions reported after the `bep-eng.dic` retirement in NVDA 2026.2jp, while strictly maintaining the permissive BSD 3-Clause license policy (CMUdict + clean-room rules).

### Key Reading Improvements in v1.1.9

- **Compound words across morphological boundaries**:
  - `outside` -> `アウトサイド` (was `アウツアイド`)
  - `itself` -> `イットセルフ` (was `イツエルフ`)
  - `bestseller` -> `ベストセラー` (was `ベスツエラー`)
  - `whatsapp` -> `ワッツアップ`
  - `whiteside` -> `ホワイトサイド`
- **Natural katakana loanwords**:
  - `pizza` / `pizzas` -> `ピザ` / `ピザズ` (was `ピーツア` / `ピーットサ`)
  - `pantsuit` -> `パンツスーツ` (was `パンツウーット` / `パントスーット`)
  - `patsy` -> `パッツィ` (was `パツイー` / `パットシー`)
  - `pulitzer` -> `ピューリッツァー`
  - `mozzarella` -> `モッツァレラ`
  - `switzerland` -> `スイス`
  - `etc` / `etcetera` -> `エトセトラ`
  - `godzilla` -> `ゴジラ`
  - `compass` -> `コンパス` (was `カムパス`)
  - `company` -> `カンパニー` (was `カムパニー`)
  - `originate` / `originated` -> `オリジネイト` / `オリジネイティド` (was `アイジネイト` / `アイジネイタド`)
- **Essential function words / prepositions**:
  - `of` -> `オブ` (was spelled out letter-by-letter `オーエフ`)
  - `to` (`トゥー`), `for` (`フォー`), `in` (`イン`), `at` (`アット`), `by` (`バイ`), `on` (`オン`)
- **Japanese proper names and cultural loanwords**:
  - `matsumura` -> `マツムラ` (was `マットスームラ` / `マツウームラ`)
  - `mitsuru` -> `ミツル` (was `ミーットスールー` / `ミーツウールー`)
  - `atsushi` -> `アツシ`
  - `suzuki` -> `スズキ` (was `サズーキー`)
  - `tanaka` -> `タナカ`
  - `jujitsu` -> `ジュウジュツ` (was `ジュージツウー`)

### Verification

- `scons.bat jtalkSync`: Successfully fetched prebuilt dictionary `v1.1.9` and verified SHA256 checksums (`jtalk-dic-v1.1.9.zip` and `mecab-dict-index-v1.1.9.exe`).
- `runJpSmokeTests.ps1`: All 7 braille/JTalk/MeCab smoke tests passed with 0 errors.
- Verified speech parsing directly with MeCab / JTalk tagger.
