### PR TITLE
Pin jtalk-dic-version to v1.1.10: refine switzerland, jujitsu, environmentalists, and acronyms

### DIFF
--- a/miscDepsJp/jptools/jtalk-dic-version.txt
+++ b/miscDepsJp/jptools/jtalk-dic-version.txt
@@ -3,10 +3,10 @@
 # nishimotz/libkuraji-jtalk-dic release.
 # See projectDocs/jp/vendor-submodules.md ("辞書のビルド時取得（方針転換）").
 repo=nishimotz/libkuraji-jtalk-dic
-tag=v1.1.9
-asset=jtalk-dic-v1.1.9.zip
-sha256=442c143a0092f47c23c6907cee9b2e4a5278621d872c600129550bde38099906
+tag=v1.1.10
+asset=jtalk-dic-v1.1.10.zip
+sha256=292e1297f828c901a0e6c9d335cca52b7f98c7e0a22bb5d43659f6a92cbd7d76
 # mecab-dict-index.exe: used by build_userdic.py to compile jtusr.dic
 # (the user dictionary). Unsigned executable; verified via checksum before use.
-tool_asset=mecab-dict-index-v1.1.9.exe
-tool_sha256=27daa29f4089b03f8f8e42662c149d46b885bd542f136d15a0b24aecc14609dc
+tool_asset=mecab-dict-index-v1.1.10.exe
+tool_sha256=29428d7ad6a2e501f647613c602d4798ba5cdcc1d054f05212dd5c0e1fa0949b


### PR DESCRIPTION
## Summary

Update JTalk extended dictionary pin to `v1.1.10` from `nishimotz/libkuraji-jtalk-dic`.

### Key Reading Refinements in v1.1.10

- **`switzerland` -> `スウィッツァーランド`** (was `スイス`): Avoids translating the country name and uses natural phonetic katakana reading (matching previous `bep-eng.dic` behavior).
- **`jujitsu` / `jiujitsu` -> `ジュウジツ`** (was `ジュウジュツ`): Matches English spelling (`-jitsu`) and established loanword usage (e.g. Brazilian Jiu-Jitsu), while `jujutsu` retains `ジュウジュツ` (Hepburn romanization).
- **`environmentalists` -> `エンバイロンメンタリスツ`** (was `エンバイロンメンタリスト`): Fixes bug where the plural form was identical to the singular form.
- **Initialisms/Acronyms**: `ceo` -> `シーイーオー` (was `シイオ`), `cia` -> `シーアイエー` (was `シアイエイ`), `aol` -> `エーオーエル` (was `エイオウエル`), `iou` -> `アイオーユー` (was `アイオウユ`).

### Verification

- `scons.bat jtalkSync`: Successfully fetched prebuilt dictionary `v1.1.10` and verified SHA256 checksums (`jtalk-dic-v1.1.10.zip` and `mecab-dict-index-v1.1.10.exe`).
- `runJpSmokeTests.ps1`: All 7 braille/JTalk/MeCab smoke tests passed with 0 errors.
- Verified reading output directly:
  - `switzerland` -> **スウィッツァーランド**
  - `jujitsu` -> **ジュウジツ**
  - `jiujitsu` -> **ジュウジツ**
  - `jujutsu` -> **ジュウジュツ**
  - `environmentalists` -> **エンバイロンメンタリスツ**
  - `ceo` -> **シーイーオー**
  - `cia` -> **シーアイエー**
  - `aol` -> **エーオーエル**
  - `iou` -> **アイオーユー**
