### PR TITLE
chore: sync releasejp enhancements to betajp and add post-release runbook

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -276,7 +276,7 @@ jobs:
       if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       shell: pwsh
       env:
-        VERSION: ${{ github.ref_name == 'releasejp' && env.version || nowdate }}
+        VERSION: ${{ github.ref_name == 'releasejp' && env.version || env.nowdate }}
       run: |
         uv run --no-active python jptools/pack_jtalk_addon.py --nowdate "$env:VERSION"
         uv run --no-active python jptools/pack_kgs_addon.py --version "$env:VERSION"

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -20,6 +20,13 @@ on:
       # Original upstream branches (master, beta, rc) removed for nvdajp
 
   workflow_dispatch:
+    inputs:
+      # BEGIN JP PATCH (releasejp signed release builds)
+      releaseTag:
+        description: 'Release tag for releasejp (e.g. release-2026.2jp-rc1 or release-2026.2jp)'
+        required: false
+        type: string
+      # END JP PATCH
 
 concurrency:
   # BEGIN JP PATCH (separate concurrency groups by event name so workflow_dispatch is not cancelled by push)
@@ -264,17 +271,17 @@ jobs:
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}${{ env.SCONS_CACHE_SUFFIX }}
-    # BEGIN JP PATCH (build JP addons on betajp workflow_dispatch so they can be attached to GitHub Release)
+    # BEGIN JP PATCH (build JP addons on betajp/releasejp workflow_dispatch so they can be attached to GitHub Release)
     - name: Build JP addons
-      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       shell: pwsh
       env:
-        VERSION: ${{ env.nowdate }}
+        VERSION: ${{ github.ref_name == 'releasejp' && env.version || nowdate }}
       run: |
         uv run --no-active python jptools/pack_jtalk_addon.py --nowdate "$env:VERSION"
         uv run --no-active python jptools/pack_kgs_addon.py --version "$env:VERSION"
     - name: Upload JP addon artifacts
-      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       uses: actions/upload-artifact@v7
       with:
         name: JP addons (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
@@ -652,7 +659,7 @@ jobs:
       run: scons %sconsLauncherOutTargets% %sconsArgs%
     - name: Rename controller client archive for JP release
       shell: pwsh
-      if: ${{ github.ref_name == 'betajp' && github.event_name == 'workflow_dispatch' }}
+      if: ${{ (github.ref_name == 'betajp' || github.ref_name == 'releasejp') && github.event_name == 'workflow_dispatch' }}
       run: |
         $cc = Get-ChildItem -Path output -Filter "nvda_*controllerClient.zip" | Select-Object -First 1
         if ($cc) {
@@ -1152,6 +1159,106 @@ jobs:
         }
         EOF
         aws s3 cp beta-meta.json s3://nvdajp/beta/beta-meta.json --content-type application/json --acl public-read
+    outputs:
+      releaseTag: ${{ steps.tag.outputs.TAG }}
+      releaseUrl: ${{ steps.tag.outputs.URL }}
+      exeName: ${{ steps.hashes.outputs.EXE_NAME }}
+      sha1: ${{ steps.hashes.outputs.SHA1 }}
+      sha256: ${{ steps.hashes.outputs.SHA256 }}
+      version: ${{ needs.buildNVDA.outputs.version }}
+  # END JP PATCH
+
+  # BEGIN JP PATCH (publish releasejp release on workflow_dispatch only)
+  publishRelease:
+    name: Publish release
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: [matrix, buildNVDA, createLauncher, createSymbols, allTestsPass]
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'releasejp'
+    concurrency:
+      group: releasejp-release
+      cancel-in-progress: true
+    steps:
+    - name: Determine tag
+      shell: bash
+      id: tag
+      run: |
+        tag="${{ inputs.releaseTag }}"
+        if [ -z "$tag" ]; then
+          echo "Error: releaseTag input is required for releasejp workflow_dispatch" >&2
+          exit 1
+        fi
+        case "$tag" in
+          release-*jp*)
+            ;;
+          *)
+            echo "Error: releaseTag must start with 'release-' and contain 'jp'" >&2
+            exit 1
+            ;;
+        esac
+        if echo "$tag" | grep -qE 'rc|beta'; then
+          prerelease_flag="--prerelease"
+        else
+          prerelease_flag=""
+        fi
+        echo "TAG=$tag" >> "$GITHUB_OUTPUT"
+        echo "URL=https://github.com/${{ github.repository }}/releases/tag/$tag" >> "$GITHUB_OUTPUT"
+        echo "PRERELEASE_FLAG=$prerelease_flag" >> "$GITHUB_OUTPUT"
+    - name: Download NVDA launcher and JP addons
+      uses: actions/download-artifact@v8
+      with:
+        name: NVDA launcher (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
+        path: output
+    - name: Download JP addons
+      uses: actions/download-artifact@v8
+      with:
+        name: JP addons (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
+        path: jptools
+    - name: Calculate hashes
+      shell: bash
+      id: hashes
+      run: |
+        exe=$(ls output/nvda*.exe | head -n 1)
+        echo "EXE_NAME=$(basename "$exe")" >> "$GITHUB_OUTPUT"
+        echo "SHA1=$(sha1sum "$exe" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+        echo "SHA256=$(sha256sum "$exe" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+    - name: Create release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PRERELEASE_FLAG: ${{ steps.tag.outputs.PRERELEASE_FLAG }}
+      run: |
+        tag="${{ steps.tag.outputs.TAG }}"
+        version="${{ needs.buildNVDA.outputs.version }}"
+        exe_name="${{ steps.hashes.outputs.EXE_NAME }}"
+        sha1="${{ steps.hashes.outputs.SHA1 }}"
+        sha256="${{ steps.hashes.outputs.SHA256 }}"
+        notes_file="/tmp/releaseNotes.md"
+        if [ -n "$PRERELEASE_FLAG" ]; then
+          title_text="Pre-release "
+          body_text="This is a pre-release of the NVDA Japanese Version. It is intended for testing and feedback before the stable release."
+        else
+          title_text=""
+          body_text="This is the stable release of the NVDA Japanese Version."
+        fi
+        {
+          echo "$body_text"
+          echo ""
+          echo "* Download: $exe_name"
+          echo "* SHA1: \`$sha1\`"
+          echo "* SHA256: \`$sha256\`"
+        } > "$notes_file"
+        gh release create "$tag" \
+          "output/$exe_name" \
+          jptools/nvdajp-jtalk-*.nvda-addon \
+          jptools/kgsbraille-*.nvda-addon \
+          output/nvda_*_controllerClientJp.zip \
+          --repo ${{ github.repository }} \
+          --title "${title_text}$version" \
+          --notes-file "$notes_file" \
+          $PRERELEASE_FLAG
     outputs:
       releaseTag: ${{ steps.tag.outputs.TAG }}
       releaseUrl: ${{ steps.tag.outputs.URL }}

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -26,6 +26,10 @@ on:
         description: 'Release tag for releasejp (e.g. release-2026.2jp-rc1 or release-2026.2jp)'
         required: false
         type: string
+      previousStableTag:
+        description: 'Previous stable release tag for Full Changelog (optional; e.g. release-2026.1.1jp). If empty, latest stable tag is used.'
+        required: false
+        type: string
       # END JP PATCH
 
 concurrency:
@@ -1229,6 +1233,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         PRERELEASE_FLAG: ${{ steps.tag.outputs.PRERELEASE_FLAG }}
+        PREVIOUS_STABLE_TAG_INPUT: ${{ inputs.previousStableTag }}
       run: |
         tag="${{ steps.tag.outputs.TAG }}"
         version="${{ needs.buildNVDA.outputs.version }}"
@@ -1238,18 +1243,40 @@ jobs:
         notes_file="/tmp/releaseNotes.md"
         if [ -n "$PRERELEASE_FLAG" ]; then
           title_text="Pre-release "
-          body_text="This is a pre-release of the NVDA Japanese Version. It is intended for testing and feedback before the stable release."
+          {
+            echo "This is a pre-release of the NVDA Japanese Version. It is intended for testing and feedback before the stable release."
+            echo ""
+            echo "* Download: $exe_name"
+            echo "* SHA1: \`$sha1\`"
+            echo "* SHA256: \`$sha256\`"
+          } > "$notes_file"
         else
           title_text=""
-          body_text="This is the stable release of the NVDA Japanese Version."
+          prev_tag="${PREVIOUS_STABLE_TAG_INPUT}"
+          if [ -z "$prev_tag" ]; then
+            prev_tag=$(gh release list --repo ${{ github.repository }} --limit 100 \
+              | awk -F '\t' '$2 !~ /Pre-release/ {print $3; exit}')
+          fi
+          {
+            echo "NVDAJP is developed by NVDA Japanese Team, based on the work of NV Access."
+            echo ""
+            echo "NVDAJP $version is a stable release."
+            echo ""
+            echo "NVDAJP contains enhancements for Japanese language users, such as JTalk TTS which can be used with the installer or portable version."
+            echo ""
+            echo "* \`$exe_name\` : launcher (installer)"
+            echo "* \`nvda_*_controllerClientJp.zip\` : SDK regarding Japanese modifications of NVDA API."
+            echo "* \`nvdajp-jtalk-*.nvda-addon\` : Japanese TTS, which is not necessary for NVDA Japanese version because it is already included. The add-on can be used with the original version of NVDA."
+            echo "* \`kgsbraille-*.nvda-addon\` : KGS braille display driver, which is not necessary for NVDA Japanese version because it is already included. The add-on can be used with the original version of NVDA."
+            echo ""
+            echo "* SHA1: \`$sha1\`"
+            echo "* SHA256: \`$sha256\`"
+            if [ -n "$prev_tag" ]; then
+              echo ""
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${prev_tag}...${tag}"
+            fi
+          } > "$notes_file"
         fi
-        {
-          echo "$body_text"
-          echo ""
-          echo "* Download: $exe_name"
-          echo "* SHA1: \`$sha1\`"
-          echo "* SHA256: \`$sha256\`"
-        } > "$notes_file"
         gh release create "$tag" \
           "output/$exe_name" \
           jptools/nvdajp-jtalk-*.nvda-addon \

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -1254,8 +1254,11 @@ jobs:
           title_text=""
           prev_tag="${PREVIOUS_STABLE_TAG_INPUT}"
           if [ -z "$prev_tag" ]; then
-            prev_tag=$(gh release list --repo ${{ github.repository }} --limit 100 \
-              | awk -F '\t' '$2 !~ /Pre-release/ {print $3; exit}')
+            # Use the REST API to find the latest non-prerelease release tag.
+            # Avoid piping `gh release list` into awk with `exit`, which causes
+            # SIGPIPE (exit code 141) and fails the step.
+            prev_tag=$(gh api "repos/${{ github.repository }}/releases?per_page=100" \
+              --jq '[.[] | select(.prerelease==false and .draft==false) | .tag_name][0] // empty')
           fi
           {
             echo "NVDAJP is developed by NVDA Japanese Team, based on the work of NV Access."

--- a/ci/scripts/setBuildVersionVars.ps1
+++ b/ci/scripts/setBuildVersionVars.ps1
@@ -29,6 +29,14 @@ if ($env:GITHUB_REF_TYPE -eq "tag" -and $env:GITHUB_REF_NAME.StartsWith("release
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 		}
 		# END JP PATCH
+		# BEGIN JP PATCH (releasejp: use 2026.2jp for workflow_dispatch signed releases)
+		if ($env:GITHUB_REF_NAME -eq "releasejp" -and $env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
+			$version = "2026.2jp"
+			$release = 1
+			$versionType = "nvdajp"
+			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+		}
+		# END JP PATCH
 		if ($env:GITHUB_REF_NAME.StartsWith("try-release-")) {
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 		}

--- a/ci/scripts/setBuildVersionVars.ps1
+++ b/ci/scripts/setBuildVersionVars.ps1
@@ -29,9 +29,9 @@ if ($env:GITHUB_REF_TYPE -eq "tag" -and $env:GITHUB_REF_NAME.StartsWith("release
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 		}
 		# END JP PATCH
-		# BEGIN JP PATCH (releasejp: use 2026.2jp for workflow_dispatch signed releases)
+		# BEGIN JP PATCH (releasejp: derive version from buildVersion.py for workflow_dispatch signed releases)
 		if ($env:GITHUB_REF_NAME -eq "releasejp" -and $env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
-			$version = "2026.2jp"
+			$version = python -c "import sys; sys.path.append('source'); import buildVersion; print(f'{buildVersion.version_year}.{buildVersion.version_major}jp')"
 			$release = 1
 			$versionType = "nvdajp"
 			Write-Output "release=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/projectDocs/jp/README.md
+++ b/projectDocs/jp/README.md
@@ -25,6 +25,12 @@
 * 変化しやすい情報（CI状況、調査ログ、暫定回避策）は `projectDocs/jp/*` に集約する。
 * 文書追加・移動時は本ファイルの索引を同時更新する。
 
+### 優先順位（正本の所在）
+
+* **日本語版の運用・仕様は `projectDocs/jp/` を正本とする。** 本家版（nvaccess）の文書（例: `projectDocs/community/releaseProcess.md`、`projectDocs/dev/*`）と食い違う場合は、`projectDocs/jp/` の記述を優先する。
+* 本家版文書は upstream との差分を作らないため**変更しない**。日本語版固有の手順・方針は `readme-nvdajp.md` と `projectDocs/jp/` に集約する。
+* 例: リリース手順は本家の `releaseProcess.md`（rc/beta/master ブランチ運用）ではなく、`projectDocs/jp/code-signing-dependencies.md`（releasejp の workflow_dispatch 署名リリース）を正本とする。
+
 ## ロードマップ
 
 * 正本: `projectDocs/jp/roadmap.md`

--- a/projectDocs/jp/code-signing-dependencies.md
+++ b/projectDocs/jp/code-signing-dependencies.md
@@ -80,6 +80,69 @@ jtalkPrep -> jtalkSync -> source -> user_docs -> dist -> jpCertExtras -> launche
 - `scons.bat source user_docs dist` を先に完了させる。
 - 必要に応じて `scons.bat jtalkSync dist` を再実行する。
 
+## GitHub Actions によるクラウド署名リリース（2026.2jp 移行）
+
+2026.2jp から `releasejp` ブランチでも `alphajp` / `betajp` と同様に、GitHub Actions の `workflow_dispatch` で Azure Key Vault 署名付きリリースビルドを行えるようになった。
+
+### 発火条件と署名の有無
+
+| ブランチ | push / pull_request | workflow_dispatch |
+|---|---|---|
+| alphajp | 署名なし | 署名あり（Azure KV） |
+| betajp | 署名なし | 署名あり（Azure KV） |
+| releasejp | 署名なし | 署名あり（Azure KV）※本 PR で追加 |
+
+- `push` / `pull_request` は常に署名なしビルドである。
+- 署名が必要なリリース / プレリリースは必ず `workflow_dispatch` で発火する。
+
+### リリースワークフローの使い分け
+
+#### alphajp（自動タグ生成）
+
+```text
+workflow_dispatch on alphajp
+  → publishAlphaRelease
+  → タグ: alphajp-{YYMMDD}{hour}
+  → 常にプレリリース
+```
+
+#### betajp（自動タグ生成）
+
+```text
+workflow_dispatch on betajp
+  → publishBetaRelease
+  → タグ: betajp-{YYYY.Mjp-beta-YYMMDD}{hour}
+  → 常にプレリリース
+  → S3 へ beta-meta.json をアップロード
+```
+
+#### releasejp（人がタグを指定）
+
+```text
+workflow_dispatch on releasejp + releaseTag 入力
+  → publishRelease
+  → タグ: 入力で指定（例: release-2026.2jp-rc1 / release-2026.2jp）
+  → rc / beta を含むタグ名 → プレリリース
+  → 含まないタグ名 → 正式リリース
+```
+
+- `releaseTag` 入力は必須。`release-` で始まり `jp` を含む形式を要求する。
+- 成果物は `nvda_2026.2jp.exe`、`nvdajp-jtalk-*.nvda-addon`、`kgsbraille-*.nvda-addon`、`nvda_*_controllerClientJp.zip`。
+
+### リリース手順例（2026.2jp RC1）
+
+1. `releasejp` ブランチを最新にする
+2. GitHub Actions → CI/CD Japanese Version → `Run workflow`
+3. ブランチ: `releasejp`、入力 `releaseTag: release-2026.2jp-rc1` で発火
+4. 全テストが通過すれば `nvda_2026.2jp.exe` が署名付きで作成され、GitHub Releases にプレリリースとして公開される
+
+RC で不備が見つかった場合は修正コミットを `releasejp` ブランチに追加し、次の `releaseTag`（例: `release-2026.2jp-rc2`）で再度発火する。OK ならば最後の RC と同じコミットに `release-2026.2jp` タグを追加して `workflow_dispatch` から正式リリースを作成する。
+
+### 更新通知
+
+- RC / プレリリースでは `version=2026.2jp`、`updateVersionType=nvdajp` として署名ビルドが作成される。
+- 実行後、NVDA の更新チェックは `2026.2jp` を自身のバージョンとして通知する。
+
 ## 関連
 
 - `jptools/scons_jp.py`

--- a/projectDocs/jp/code-signing-dependencies.md
+++ b/projectDocs/jp/code-signing-dependencies.md
@@ -144,6 +144,36 @@ RC で不備が見つかった場合は修正コミットを `releasejp` ブラ�
 - RC / プレリリースでは `version=2026.2jp`、`updateVersionType=nvdajp` として署名ビルドが作成される。
 - 実行後、NVDA の更新チェックは `2026.2jp` を自身のバージョンとして通知する。
 
+### リリース公開後の作業（ランブック）
+
+正式リリースの公開完了後、以下の運用作業を実施する。
+
+#### 1. リリースと連動したディスカッションの作成（前提踏襲）
+
+正式リリースの公開後、GitHub Releases と連動したディスカッション（カテゴリ「お知らせ」）を作成・紐づける。
+GitHub Releases API（`PATCH`）で `discussion_category_name` を指定することで、過去リリース（2026.1jp、2026.1.1jp 等）と同様に自動生成および相互リンクが行われる。
+
+```bash
+# タグ名から release ID を取得してディスカッションを生成・紐づけ
+gh api -X PATCH "repos/nvdajp/nvdajp/releases/$(gh api repos/nvdajp/nvdajp/releases/tags/<tag_name> --jq .id)" \
+  -f discussion_category_name="お知らせ"
+
+# 確認（discussion_url が設定されていること）
+gh api "repos/nvdajp/nvdajp/releases/tags/<tag_name>" --jq '{name: .name, tag_name: .tag_name, discussion_url: .discussion_url}'
+```
+
+#### 2. 次期マイルストーンへの自動割り当て切り替え
+
+新バージョンの正式リリース完了後、PRマージ時のマイルストーン自動付与先（`.github/workflows/assign-milestone-on-close.yml`）を次期マイルストーンに切り替える。
+
+```powershell
+# 次期マイルストーンの数値 ID を確認（例: 2026.3jp の ID が 81 の場合）
+gh variable set MILESTONE_ID --body "81" --repo nvdajp/nvdajp
+
+# 設定確認
+gh variable list --repo nvdajp/nvdajp
+```
+
 ## 関連
 
 - `jptools/scons_jp.py`
@@ -151,3 +181,4 @@ RC で不備が見つかった場合は修正コミットを `releasejp` ブラ�
 - `jptools/certBuild2023.cmd`
 - `projectDocs/jp/README.md`
 - 詳細アーカイブ: `projectDocs/jp/archive/code-signing-dependencies-details.md`
+

--- a/projectDocs/jp/code-signing-dependencies.md
+++ b/projectDocs/jp/code-signing-dependencies.md
@@ -92,7 +92,8 @@ jtalkPrep -> jtalkSync -> source -> user_docs -> dist -> jpCertExtras -> launche
 | betajp | 署名なし | 署名あり（Azure KV） |
 | releasejp | 署名なし | 署名あり（Azure KV）※本 PR で追加 |
 
-- `push` / `pull_request` は常に署名なしビルドである。
+- ブランチへの `push` / `pull_request` は常に署名なしビルドである。
+- タグの `push` は CI を発火しない（`on.push` は `branches` のみで `tags` を対象にしていない）。
 - 署名が必要なリリース / プレリリースは必ず `workflow_dispatch` で発火する。
 
 ### リリースワークフローの使い分け
@@ -136,7 +137,7 @@ workflow_dispatch on releasejp + releaseTag 入力
 3. ブランチ: `releasejp`、入力 `releaseTag: release-2026.2jp-rc1` で発火
 4. 全テストが通過すれば `nvda_2026.2jp.exe` が署名付きで作成され、GitHub Releases にプレリリースとして公開される
 
-RC で不備が見つかった場合は修正コミットを `releasejp` ブランチに追加し、次の `releaseTag`（例: `release-2026.2jp-rc2`）で再度発火する。OK ならば最後の RC と同じコミットに `release-2026.2jp` タグを追加して `workflow_dispatch` から正式リリースを作成する。
+RC で不備が見つかった場合は修正コミットを `releasejp` ブランチに追加し、次の `releaseTag`（例: `release-2026.2jp-rc2`）で再度発火する。OK ならば `releaseTag: release-2026.2jp` で `workflow_dispatch` を発火して正式リリースを作成する。タグは手動で打たないこと。`publishRelease` ジョブが `gh release create` により `releasejp` ブランチの HEAD に `release-2026.2jp` タグを自動生成するため、手動でタグを打つとビルド対象リビジョンとタグのリビジョンがずれる恐れがある。
 
 ### 更新通知
 

--- a/readme-nvdajp.md
+++ b/readme-nvdajp.md
@@ -128,13 +128,13 @@ Issue のクローズには反応しない。
 
 ### 設定方法
 
-リポジトリ変数 `MILESTONE_ID` に、自動割り当て先マイルストーンの数値 ID を設定する。現在の対象は [2026.2jp](https://github.com/nvdajp/nvdajp/milestone/78)（ID: `78`）。
+リポジトリ変数 `MILESTONE_ID` に、自動割り当て先マイルストーンの数値 ID を設定する。現在の対象は [2026.3jp](https://github.com/nvdajp/nvdajp/milestone/81)（ID: `81`）。
 
 ```powershell
-gh variable set MILESTONE_ID --body "78" --repo nvdajp/nvdajp
+gh variable set MILESTONE_ID --body "81" --repo nvdajp/nvdajp
 ```
 
-ID は GitHub の Milestones 画面 URL 末尾の数字（例: `.../milestone/78` → `78`）。設定確認:
+ID は GitHub の Milestones 画面 URL 末尾の数字（例: `.../milestone/81` → `81`）。設定確認:
 
 ```powershell
 gh variable list --repo nvdajp/nvdajp
@@ -142,11 +142,12 @@ gh variable list --repo nvdajp/nvdajp
 
 ### 運用手順
 
-1. 新リリース準備時に GitHub でマイルストーン（例: `2026.2jp`）を作成する
+1. 新リリース準備時に GitHub でマイルストーン（例: `2026.3jp`）を作成する
 2. マイルストーン URL 末尾の ID を確認する
 3. `MILESTONE_ID` をその ID に更新する（上記 `gh variable set`）
 
 リリースノート作成時に該当マイルストーンでフィルタし、変更点を把握しやすくする。
+正式リリース公開後のディスカッション連携手順などは `projectDocs/jp/code-signing-dependencies.md` の「リリース公開後の作業（ランブック）」を参照。
 
 ## git 運用方針とトラブルシューティング
 

--- a/readme-nvdajp.md
+++ b/readme-nvdajp.md
@@ -9,6 +9,12 @@
 - この `readme-nvdajp.md` は **恒常的な手順と最短コマンド**（初回セットアップ、日常運用の入口）を扱う。
 - `projectDocs/jp/README.md` から辿れる詳細文書は **テーマ別の詳細仕様・背景・進行中の課題**（ロードマップ、分析、検証結果）を扱う。
 
+### 優先順位（正本の所在）
+
+- **日本語版の運用・仕様は `projectDocs/jp/` を正本とする。** 本家版（nvaccess）の文書（例: `projectDocs/community/releaseProcess.md`、`projectDocs/dev/*`）と内容が食い違う場合は、`projectDocs/jp/` の記述を優先する。
+- 本家版文書は upstream との差分を作らないため**変更しない**。日本語版固有の手順・方針は `readme-nvdajp.md` と `projectDocs/jp/` に集約する。
+- 例: リリース手順は本家の `releaseProcess.md`（rc/beta/master ブランチ運用）ではなく、`projectDocs/jp/code-signing-dependencies.md`（releasejp の workflow_dispatch 署名リリース）を正本とする。
+
 ---
 
 ## ビルド環境準備とソースコード取得


### PR DESCRIPTION
## 概要
- releasejp ブランチで整備された GitHub Actions による署名リリースビルド機能（PR #724, #725 および SIGPIPE 修正、タグ運用ドキュメント）を betajp へ取り込みます。
- 2026.2jp 正式リリース完了に伴い、code-signing-dependencies.md にリリース公開後の作業（GitHub Releases 連動ディスカッション作成、次期マイルストーン切り替え）のランブックを追記しました。
- readme-nvdajp.md の MILESTONE_ID 例を 81 (2026.3jp) に更新しました。

## 主な変更点
1. **workflow**: .github/workflows/testAndPublish.yml に releasejp 向け publishRelease ジョブおよび関連修正を取り込み
2. **version**: ci/scripts/setBuildVersionVars.ps1 に releasejp 向けバージョン取得処理を取り込み
3. **docs**:
   - projectDocs/jp/README.md: projectDocs/jp が正本であることを明記
   - projectDocs/jp/code-signing-dependencies.md: クラウド署名リリース仕様、および「リリース公開後の作業（ランブック）」を追記
   - readme-nvdajp.md: 正本優先順位の明記、MILESTONE_ID の 2026.3jp (81) への更新とランブックへの参照追記
