### PR TITLE
fix(braille): resolve deprecation warnings in KGS braille drivers for 2026.3

### DIFF
--- a/source/brailleDisplayDrivers/brailleMemo.py
+++ b/source/brailleDisplayDrivers/brailleMemo.py
@@ -10,7 +10,20 @@
 from .kgs import _connectionBeepsEnabled
 
 import braille
-import brailleInput
+try:
+	import braille.display.driver
+	import braille.display.gesture
+	_BrailleDisplayDriver = braille.display.driver.BrailleDisplayDriver
+	_BrailleDisplayGesture = braille.display.gesture.BrailleDisplayGesture
+except (ImportError, AttributeError):
+	_BrailleDisplayDriver = braille.BrailleDisplayDriver
+	_BrailleDisplayGesture = braille.BrailleDisplayGesture
+try:
+	import braille.input.gesture
+	_BrailleInputGesture = braille.input.gesture.BrailleInputGesture
+except (ImportError, AttributeError):
+	import brailleInput
+	_BrailleInputGesture = brailleInput.BrailleInputGesture
 import inputCore
 import hwPortUtils
 import time
@@ -372,7 +385,7 @@ def bmDisConnect(hBrl, port):
 	return ret
 
 
-class BrailleDisplayDriver(braille.BrailleDisplayDriver):
+class BrailleDisplayDriver(_BrailleDisplayDriver):
 	name = "brailleMemo"
 	# Translators: braille display driver description
 	description = _("BrailleMemo experimental")
@@ -542,7 +555,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(_BrailleDisplayGesture, _BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, names, routingIndex):

--- a/source/brailleDisplayDrivers/kgs.py
+++ b/source/brailleDisplayDrivers/kgs.py
@@ -9,6 +9,14 @@
 
 import bdDetect
 import braille
+try:
+	import braille.display.driver
+	import braille.display.gesture
+	_BrailleDisplayDriver = braille.display.driver.BrailleDisplayDriver
+	_BrailleDisplayGesture = braille.display.gesture.BrailleDisplayGesture
+except (ImportError, AttributeError):
+	_BrailleDisplayDriver = braille.BrailleDisplayDriver
+	_BrailleDisplayGesture = braille.BrailleDisplayGesture
 import inputCore
 import hwPortUtils
 import time
@@ -433,7 +441,7 @@ def bmDisConnect(hBrl, port):
 	return ret
 
 
-class BrailleDisplayDriver(braille.BrailleDisplayDriver):
+class BrailleDisplayDriver(_BrailleDisplayDriver):
 	name = "kgs"
 	# Translators: braille display driver description
 	description = _("KGS BrailleMemo series")
@@ -735,7 +743,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.BrailleDisplayGesture):
+class InputGesture(_BrailleDisplayGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, names, routingIndex):

--- a/source/brailleDisplayDrivers/kgsbn46.py
+++ b/source/brailleDisplayDrivers/kgsbn46.py
@@ -8,6 +8,14 @@
 # Copyright (C) 2011-2019 Takuya Nishimoto
 
 import braille
+try:
+	import braille.display.driver
+	import braille.display.gesture
+	_BrailleDisplayDriver = braille.display.driver.BrailleDisplayDriver
+	_BrailleDisplayGesture = braille.display.gesture.BrailleDisplayGesture
+except (ImportError, AttributeError):
+	_BrailleDisplayDriver = braille.BrailleDisplayDriver
+	_BrailleDisplayGesture = braille.BrailleDisplayGesture
 import inputCore
 import time
 import tones
@@ -214,7 +222,7 @@ def bmDisConnect(hBrl, port):
 	return ret
 
 
-class BrailleDisplayDriver(braille.BrailleDisplayDriver):
+class BrailleDisplayDriver(_BrailleDisplayDriver):
 	name = "kgsbn46"
 	# Translators: braille display driver description
 	description = _("KGS BrailleNote 46C/46D")
@@ -360,7 +368,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.BrailleDisplayGesture):
+class InputGesture(_BrailleDisplayGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, names, routingIndex):


### PR DESCRIPTION
## Summary

NVDA 2026.3 upstream で行われた点字関連モジュールの大規模リファクタリングに伴い、起動時（`bdDetect.initialize` が利用可能な点字ディスプレイ一覧をインポート走査する際）に KGS 点字ドライバから非推奨警告（`WARNING - utils._deprecate.module_getattr`）がログ出力されていた問題を修正します。

### 原因
NVDA 2026.3 では以下のシンボルが新パッケージ配下へ移動し、旧パスからのインポートは `utils._deprecate.handleDeprecations` により警告が出力されるようになりました：
- `braille.BrailleDisplayDriver` -> `braille.display.driver.BrailleDisplayDriver`
- `braille.BrailleDisplayGesture` -> `braille.display.gesture.BrailleDisplayGesture`
- `brailleInput.BrailleInputGesture` -> `braille.input.gesture.BrailleInputGesture`

### 対応内容
対象ドライバ：
- `source/brailleDisplayDrivers/kgs.py`
- `source/brailleDisplayDrivers/brailleMemo.py`
- `source/brailleDisplayDrivers/kgsbn46.py`

上記ドライバにおいて、新名前空間からインポートを行い、旧 NVDA 環境向けアドオンとして配布された場合のフォールバック（`try ... except (ImportError, AttributeError)`）を実装しました。これにより、ログ警告が完全に抑止されるとともに、過去バージョン向けアドオンとしての後方互換性も維持されます。

### テスト
- `uv run --group unit-tests python -m unittest tests.unit.test_braille.test_brailleDisplayDrivers` パス（30 tests, OK）
- サブクラス関係および現代的なクラス継承関係の確認完了
- 変更箇所の ruff チェック通過
