### PR TITLE
ci: increase createLauncher timeout to 45 minutes

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -604,7 +604,7 @@ jobs:
     name: Create launcher
     runs-on: ${{ needs.matrix.outputs.defaultRunner }}
     needs: [matrix, buildNVDA]
-    timeout-minutes: 35
+    timeout-minutes: 45
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
Increase createLauncher job timeout from 35 to 45 minutes to prevent cancellation during Azure Key Vault signed releases.