### PR TITLE
jtalk: switch prebuilt dictionary source to nvdajp/nvdajp-jtalk-dic v1.0.0

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -64,9 +64,11 @@ env:
   # Bumped to v6: jtalkDicSource default changed prebuilt -> local to restore
   # bep-eng.dic English readings; cached dictionary from the prebuilt path must
   # not be reused.
+  # Bumped to v7: jtalkDicSource default changed back to prebuilt using
+  # nvdajp/nvdajp-jtalk-dic v1.0.0 release (which includes bep-eng.dic).
   # Do not bump on every CI failure; investigate logs first.
   # See projectDocs/jp/tab-character-analysis.md "キャッシュキーで無効化".
-  SCONS_CACHE_SUFFIX: "-jp-v6"
+  SCONS_CACHE_SUFFIX: "-jp-v7"
 
 jobs:
   matrix:

--- a/jptools/scons_jp.py
+++ b/jptools/scons_jp.py
@@ -765,10 +765,6 @@ def register_jp_builders(env: Any, dist_target: Any | None = None, source_dir: A
 			marker_path.write_text(marker_expected, encoding="utf-8")
 
 			print(f"jtalkSync: prebuilt dictionary installed (tag={pin['tag']}, sha256={digest}).")
-			print(
-				"jtalkSync: note: the prebuilt dictionary omits bep-eng.dic (GPL); "
-				"see projectDocs/jp/vendor-submodules.md.",
-			)
 			return 0
 
 		def _fetch_prebuilt_tool(repo_root: Path, dest_path: Path) -> int:

--- a/miscDepsJp/jptools/jtalk-dic-version.txt
+++ b/miscDepsJp/jptools/jtalk-dic-version.txt
@@ -1,12 +1,12 @@
 # Pin for the optional prebuilt JTalk dictionary (jtalkDicSource=prebuilt,
 # the default). Update via an explicit PR after a new
-# nishimotz/libkuraji-jtalk-dic release.
+# nvdajp/nvdajp-jtalk-dic release.
 # See projectDocs/jp/vendor-submodules.md ("辞書のビルド時取得（方針転換）").
-repo=nishimotz/libkuraji-jtalk-dic
-tag=v1.1.12
-asset=jtalk-dic-v1.1.12.zip
-sha256=1bf24933d1a7d061bb455ab7316b7c97369865f38350d31c14c2cbde94dc0e62
+repo=nvdajp/nvdajp-jtalk-dic
+tag=v1.0.0
+asset=jtalk-dic-v1.0.0.zip
+sha256=a7169a942a4903914c5997c45639a8a15513be34d2721d41d2dd4674669dfb74
 # mecab-dict-index.exe: used by build_userdic.py to compile jtusr.dic
 # (the user dictionary). Unsigned executable; verified via checksum before use.
-tool_asset=mecab-dict-index-v1.1.12.exe
-tool_sha256=56f4ef69aa8136d16cc7a580f97449ce9ab92dd85ec5fadb9dca0501496bd5f3
+tool_asset=mecab-dict-index-v1.0.0.exe
+tool_sha256=f4cf8481925ce1dd7f6684299940651947924d2acdc0647cd70ca0c605d4da18

--- a/projectDocs/jp/vendor-submodules.md
+++ b/projectDocs/jp/vendor-submodules.md
@@ -43,9 +43,9 @@ JTalk 拡張辞書（NAIST-JDIC + nvdajp 独自拡張）は、点訳エンジン
 
 ### 方針転換の内容
 
-- **既定は `prebuilt`（2026-07-06 再改定）**: `libkuraji-jtalk-dic` の CI がビルドした辞書一式（`sys.dic` / `matrix.bin` / `char.bin` / `unk.dic` / `dicrc` / `DIC_VERSION` の 6 ファイル）を、`miscDepsJp/jptools/jtalk-dic-version.txt` に pin されたリリースタグ＋SHA256 チェックサムで検証したうえで取得・展開する（`scons jtalkSync`、引数なしで有効）。署名ビルドを含む全てのビルドがこの経路を使う。
-  - **再改定の理由**: JTalk 音声合成の利用者シェアは OneCore 音声の数分の一まで縮小しており、`bep-eng.dic`（GPL、除外済み）が担っていた英単語読みの網羅性低下（テストコーパス外の一般語彙）の実害は小さいと判断した。ビルド時間短縮（ローカルでの `mecab-dict-index` コンパイル・辞書ビルドを省略）のメリットを優先する。
-  - `libkuraji-jtalk-dic` は BSD 3-Clause のため GPL 由来の `bep-eng.dic`（英単語読みエントリ、`nvdajp-eng-dic` の元）を含まないが、この読みは `replace_alphabet_morphs` により点訳結果では常に元のアルファベット表記に上書きされる（実測確認済み）。**影響するのは JTalk の音声合成（発音）のみで、点訳精度は変わらない。** `libkuraji-jtalk-dic` v1.0.2 でテストコーパス（`mecabHarness.json`）既知ケースはクリーンルーム代替エントリで対応済み（0 件不一致）。
+- **既定は `prebuilt`**: `nvdajp/nvdajp-jtalk-dic`（GPL-2.0）の CI がビルドした辞書一式（`sys.dic` / `matrix.bin` / `char.bin` / `unk.dic` / `dicrc` / `DIC_VERSION` の 6 ファイル）を、`miscDepsJp/jptools/jtalk-dic-version.txt` に pin されたリリースタグ＋SHA256 チェックサムで検証したうえで取得・展開する（`scons jtalkSync`、引数なしで有効）。署名ビルドを含む全てのビルドがこの経路を使う。
+  - **`bep-eng.dic` を同梱**: この prebuilt 辞書は `bep-eng.dic`（GPL）を含んでビルドされており、英語単語の読み（カタカナ発音）の退行なしに、ビルド時間短縮（ローカルでの `mecab-dict-index` コンパイル・辞書ビルドを省略）のメリットを享受できる。
+  - 点訳エンジン側の [nishimotz/libkuraji-jtalk-dic](https://github.com/nishimotz/libkuraji-jtalk-dic)（BSD 3-Clause）とは独立した、nvdajp 専用の JTalk 拡張辞書リリースである。
 - **`local`（ローカルビルド）は明示的なオプトインとして維持**: `scons jtalkSync jtalkDicSource=local` で、リポジトリ内の NAIST-JDIC ソース＋ nvdajp 拡張エントリを `mecab-dict-index` でビルドする経路を使う。辞書の内容（品詞 ID・カスタムエントリ等）を編集する開発（roadmap タスク 2.8 等）では、変更が `libkuraji-jtalk-dic` のリリースに反映される前にこちらで検証する必要がある。
 - **チェックサム不一致時はローカルビルドへの黙ったフォールバックをしない**: ビルドを失敗させる。取得内容の完全性検証は妥協しない。
 - **pin は明示的な PR で更新する**: `latest` を追わず、固定タグ＋ハッシュを記録するファイル（`miscDepsJp/jptools/jtalk-dic-version.txt`）を用意し、更新は通常の依存バージョン bump と同様にレビューを経る。

--- a/sconstruct
+++ b/sconstruct
@@ -86,14 +86,13 @@ vars.Add("apiSigningToken", "The API key for the signing service", "")
 vars.Add(
 	EnumVariable(
 		"jtalkDicSource",
-		"How jtalkSync obtains the JTalk extended dictionary: 'local' (default) "
-		"builds it from vendored NAIST-JDIC source plus bep-eng.dic (GPL), so "
-		"English word readings match the pre-CMUdict behaviour; 'prebuilt' "
+		"How jtalkSync obtains the JTalk extended dictionary: 'prebuilt' (default) "
 		"downloads a pinned, checksum-verified release from "
-		"nishimotz/libkuraji-jtalk-dic instead (BSD 3-Clause, bep-eng.dic omitted; "
-		"no English-reading regression protection). See "
-		"projectDocs/jp/vendor-submodules.md",
-		"local",
+		"nvdajp/nvdajp-jtalk-dic (GPL-2.0, includes bep-eng.dic English word "
+		"readings); 'local' builds it from vendored NAIST-JDIC source plus "
+		"bep-eng.dic instead (no network needed; required when editing dictionary "
+		"content, see projectDocs/jp/vendor-submodules.md)",
+		"prebuilt",
 		["local", "prebuilt"],
 	),
 )

--- a/source/libkuraji/jtalk_dic.py
+++ b/source/libkuraji/jtalk_dic.py
@@ -29,15 +29,15 @@ import zipfile
 from pathlib import Path
 from collections.abc import Callable
 
-# Pinned default release tag of libkuraji-jtalk-dic. Override with the
+# Pinned default release tag of nvdajp-jtalk-dic. Override with the
 # LIBKURAJI_JTALK_DIC_TAG environment variable. Bump this when a new
 # dictionary release is validated against the harness. Keep this in sync
 # with miscDepsJp/jptools/jtalk-dic-version.txt (checked by
 # tests/unit/test_jpDicPins.py).
-DEFAULT_DIC_TAG = "v1.1.12"
+DEFAULT_DIC_TAG = "v1.0.0"
 
 # Owner/repo of the dictionary release.
-DIC_REPO = "nishimotz/libkuraji-jtalk-dic"
+DIC_REPO = "nvdajp/nvdajp-jtalk-dic"
 
 # Asset name pattern for the dictionary zip. Must match release-dic.yml
 # in libkuraji-jtalk-dic.


### PR DESCRIPTION
## Summary
- JTalk 拡張辞書の prebuilt 配布元を新設リポジトリ [nvdajp/nvdajp-jtalk-dic](https://github.com/nvdajp/nvdajp-jtalk-dic) (v1.0.0) に更新しました。
- この prebuilt 辞書は bep-eng.dic（GPL）を含んでビルドされており、英語単語の読み（カタカナ発音）の退行なしに、CI およびローカル開発でのビルド時間短縮（毎回の mecab-dict-index コンパイルおよび辞書生成のスキップ）を実現します。
- sconstruct の jtalkDicSource 既定値を prebuilt に戻しました。
- キャッシュを更新するため SCONS_CACHE_SUFFIX を -jp-v7 に bump しました。

## Test Plan
- scons jtalkSync: nvdajp/nvdajp-jtalk-dic/releases/download/v1.0.0/jtalk-dic-v1.0.0.zip をダウンロードし、チェックサム検証・展開が正常に行われることを確認。
- powershell -File jptools/verifyJtalkDictionary.ps1 -Strict: 8件の検証ケースがすべて OK。
- python miscDepsJp/jptools/mecabRunner.py: テストハーネスの不一致 0 件。